### PR TITLE
Bug: Don't break word on apostrophes

### DIFF
--- a/src/common/LyricTokenizer.ts
+++ b/src/common/LyricTokenizer.ts
@@ -1,5 +1,5 @@
 export const tokenize = (lineOfLyrics: string): string[] => {
-    const matches = lineOfLyrics.match(/(\w+|\W)/g);
+    const matches = lineOfLyrics.match(/((\w|')+|[^\w'])/g);
     if (matches === null) {
         return [];
     }

--- a/src/common/test/LyricTokenizer.test.ts
+++ b/src/common/test/LyricTokenizer.test.ts
@@ -92,6 +92,27 @@ describe("lyric tokenizer", () => {
             const results = tokenize("Ne,ver gonna");
             expect(results).toEqual(["Ne", ",", "ver", " ", "gonna"]);
         });
+
+        test("apostrophes don't break the word", () => {
+            const results = tokenize(
+                "A full commitment's what I'm thinking of"
+            );
+            expect(results).toEqual([
+                "A",
+                " ",
+                "full",
+                " ",
+                "commitment's",
+                " ",
+                "what",
+                " ",
+                "I'm",
+                " ",
+                "thinking",
+                " ",
+                "of",
+            ]);
+        });
     });
 
     describe("unicode", () => {


### PR DESCRIPTION
Prevent odd highlighting behaviour in English

Old behaviour: "I'm" gets split into 3 highlightable parts: `I`, `'`', `m`
This fixes it and keeps it as one token.