### PR TITLE
Make build path relative for Github Pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "build": "react-scripts build",
         "test": "react-scripts test --env=jest-environment-jsdom-sixteen",
         "eject": "react-scripts eject",
-        "build-github-pages": "PUBLIC_URL=http://veedubyou.github.io/chord-paper-fe yarn build"
+        "build-github-pages": "PUBLIC_URL=/chord-paper-fe yarn build"
     },
     "eslintConfig": {
         "extends": "react-app"


### PR DESCRIPTION
Use a relative build path instead of an absolute one - there were some issues with mixed http/https, and it's better to just let relative paths worry about the protocol.