### PR TITLE
Bug: Don't allow two consecutive blocks with no chords

### DIFF
--- a/src/common/ChordModel/ChordLinePatcher.ts
+++ b/src/common/ChordModel/ChordLinePatcher.ts
@@ -87,11 +87,17 @@ class ChordLineIterator {
         }
 
         if (this.prependLyrics !== "") {
-            this.chordLine.elements.splice(
-                0,
-                0,
-                new ChordBlock({ chord: "", lyric: this.prependLyrics })
-            );
+            const firstBlock = this.chordLine.elements[0];
+            // merge if first block has no chords anyway
+            if (firstBlock.chord === "") {
+                firstBlock.lyric = this.prependLyrics + firstBlock.lyric;
+            } else {
+                this.chordLine.elements.splice(
+                    0,
+                    0,
+                    new ChordBlock({ chord: "", lyric: this.prependLyrics })
+                );
+            }
         }
     }
 }

--- a/src/common/ChordModel/test/ChordLinePatcher.test.ts
+++ b/src/common/ChordModel/test/ChordLinePatcher.test.ts
@@ -96,23 +96,49 @@ describe("ChordLinePatcher", () => {
             });
         });
 
-        test("adding a word in the beginning of the line", () => {
-            replaceChordLineLyrics(
-                chordLine,
-                "Verse: It's your fault really that I'm in trouble"
-            );
+        describe("adding a word in the beginning of the line", () => {
+            test("with a chord at the beginning", () => {
+                replaceChordLineLyrics(
+                    chordLine,
+                    "Verse: It's your fault that I'm in trouble"
+                );
 
-            expect(chordLine.elements[0]).toMatchObject({
-                chord: "",
-                lyric: "Verse: ",
+                expect(chordLine.elements[0]).toMatchObject({
+                    chord: "",
+                    lyric: "Verse: ",
+                });
+                expect(chordLine.elements[1]).toMatchObject({
+                    chord: "F",
+                    lyric: "It's your fault ",
+                });
+                expect(chordLine.elements[2]).toMatchObject({
+                    chord: "C",
+                    lyric: "that I'm in trouble",
+                });
             });
-            expect(chordLine.elements[1]).toMatchObject({
-                chord: "F",
-                lyric: "It's your fault really ",
-            });
-            expect(chordLine.elements[2]).toMatchObject({
-                chord: "C",
-                lyric: "that I'm in trouble",
+
+            test("with no chord at the beginning", () => {
+                chordLine = new ChordLine([
+                    new ChordBlock({ chord: "", lyric: "It's your fault " }),
+                    new ChordBlock({
+                        chord: "C",
+                        lyric: "that I'm in trouble",
+                    }),
+                ]);
+
+                replaceChordLineLyrics(
+                    chordLine,
+                    "Verse: It's your fault that I'm in trouble"
+                );
+
+                expect(chordLine.elements[0]).toMatchObject({
+                    chord: "",
+                    lyric: "Verse: It's your fault ",
+                });
+                expect(chordLine.elements[1]).toMatchObject({
+                    chord: "C",
+                    lyric: "that I'm in trouble",
+                });
             });
         });
     });


### PR DESCRIPTION
When patching a line of lyrics, a bug occurs where it's possible to end up with two consecutive blocks with no chords. this just patches that such that in those cases, the lyrics are just merged into the same block.