### PR TITLE
Change chord edit/insert to hover button instead of clicking on word

### DIFF
--- a/src/components/Block.tsx
+++ b/src/components/Block.tsx
@@ -132,7 +132,11 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
 
     let chordRow: React.ReactElement;
     if (!editing) {
-        chordRow = <ChordSymbol>{props.chordBlock.chord}</ChordSymbol>;
+        chordRow = (
+            <Box onClick={clickHandler(0)}>
+                <ChordSymbol>{props.chordBlock.chord}</ChordSymbol>
+            </Box>
+        );
     } else {
         chordRow = (
             <Box data-testid="ChordEdit">

--- a/src/components/Block.tsx
+++ b/src/components/Block.tsx
@@ -1,4 +1,12 @@
-import { Typography, withStyles, Theme, Grid, Box } from "@material-ui/core";
+import {
+    Typography,
+    withStyles,
+    Theme,
+    Grid,
+    Box,
+    Tooltip as UnstyledTooltip,
+    Button,
+} from "@material-ui/core";
 import React, { useState } from "react";
 
 import { DataTestID } from "../common/DataTestID";
@@ -7,6 +15,8 @@ import ChordSymbol from "./ChordSymbol";
 import { IDable } from "../common/ChordModel/Collection";
 import TextInput from "./TextInput";
 import { ChordBlock } from "../common/ChordModel/ChordBlock";
+import { fade } from "@material-ui/core/styles/colorManipulator";
+import UnstyledMusicNoteRoundedIcon from "@material-ui/icons/MusicNoteRounded";
 
 interface BlockProps extends DataTestID {
     chordBlock: ChordBlock;
@@ -14,10 +24,24 @@ interface BlockProps extends DataTestID {
     onBlockSplit?: (id: IDable<"ChordBlock">, splitIndex: number) => void;
 }
 
+const MusicNoteRoundedIcon = withStyles({
+    root: {
+        color: "white",
+    },
+})(UnstyledMusicNoteRoundedIcon);
+
+const Tooltip = withStyles((theme: Theme) => ({
+    tooltip: {
+        padding: 0,
+        background: fade(theme.palette.secondary.light, 0.9),
+        margin: 0,
+    },
+}))(UnstyledTooltip);
+
 const WordTarget = withStyles((theme: Theme) => ({
     root: {
         "&:hover": {
-            color: theme.palette.secondary.main,
+            color: theme.palette.primary.main,
         },
         cursor: "pointer",
     },
@@ -27,7 +51,7 @@ const SpaceTarget = withStyles((theme: Theme) => ({
     root: {
         whiteSpace: "pre",
         "&:hover": {
-            backgroundColor: theme.palette.secondary.light,
+            backgroundColor: theme.palette.primary.light,
         },
         cursor: "pointer",
     },
@@ -42,10 +66,12 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
         lyricTokens = [inflatingWhitespace()];
     }
 
-    const clickHandler = (
+    const clickHandler: (
         tokenIndex: number
-    ): ((event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => void) => {
-        return (event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
+    ) => (event: React.MouseEvent<HTMLButtonElement>) => void = (
+        tokenIndex: number
+    ) => {
+        return (event: React.MouseEvent<HTMLButtonElement>) => {
             // block splitting happens after the first token
             // as first token is already aligned with the current chord
             if (tokenIndex !== 0 && props.onBlockSplit) {
@@ -59,18 +85,37 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
 
     const lyricBlock = (lyric: string, index: number): React.ReactElement => {
         const typographyProps = {
-            key: index,
             variant: "h5" as "h5",
             display: "inline" as "inline",
-            onClick: clickHandler(index),
             "data-testid": `Token-${index}`,
         };
 
+        const chordButton = (
+            <Button onClick={clickHandler(index)} data-testid="ChordEditButton">
+                <MusicNoteRoundedIcon />
+            </Button>
+        );
+
+        let lyricBlock: React.ReactElement;
         if (isWhitespace(lyric)) {
-            return <SpaceTarget {...typographyProps}>{lyric}</SpaceTarget>;
+            lyricBlock = (
+                <SpaceTarget {...typographyProps}>{lyric}</SpaceTarget>
+            );
         } else {
-            return <WordTarget {...typographyProps}>{lyric}</WordTarget>;
+            lyricBlock = <WordTarget {...typographyProps}>{lyric}</WordTarget>;
         }
+
+        return (
+            <Tooltip
+                key={index}
+                title={chordButton}
+                placement="top-start"
+                disableFocusListener={true}
+                interactive
+            >
+                {lyricBlock}
+            </Tooltip>
+        );
     };
 
     const lyricBlocks = lyricTokens.map((lyricToken: string, index: number) =>

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -129,6 +129,7 @@ const TextInput: React.FC<TextInputProps> = (
                 fontSize: fontSize,
                 opacity: 1,
                 background: grey[100],
+                tabSize: "60px",
             },
         };
 

--- a/src/components/TextInput.tsx
+++ b/src/components/TextInput.tsx
@@ -129,7 +129,6 @@ const TextInput: React.FC<TextInputProps> = (
                 fontSize: fontSize,
                 opacity: 1,
                 background: grey[100],
-                tabSize: "60px",
             },
         };
 

--- a/src/test/chords.test.tsx
+++ b/src/test/chords.test.tsx
@@ -105,7 +105,11 @@ describe("Changing the chord", () => {
             "Block-1",
             "Token-0"
         );
-        userEvent.click(token);
+
+        fireEvent.mouseOver(token);
+        const editButton = await findByTestId("ChordEditButton");
+        expect(editButton).toBeInTheDocument();
+        fireEvent.click(editButton);
     });
 
     test("it takes input and retains new chord changes", async () => {
@@ -170,7 +174,11 @@ describe("inserting a chord", () => {
             "Block-1",
             "Token-2"
         );
-        userEvent.click(token);
+
+        fireEvent.mouseOver(token);
+        const editButton = await findByTestId("ChordEditButton");
+        expect(editButton).toBeInTheDocument();
+        fireEvent.click(editButton);
 
         chordEdit = async () =>
             await findByTestIdChain(


### PR DESCRIPTION
Make editing a chord a tooltip hover button for now, until a better design is implemented.

<img width="459" alt="image" src="https://user-images.githubusercontent.com/5819893/84260309-aa938180-aace-11ea-9795-854e22a068b2.png">
