### PR TITLE
Add invisible target for first lyric token

### DIFF
--- a/src/components/ChordSymbol.tsx
+++ b/src/components/ChordSymbol.tsx
@@ -3,6 +3,7 @@ import { Typography, Theme } from "@material-ui/core";
 import { inflateIfEmpty } from "../common/Whitespace";
 import { withStyles } from "@material-ui/styles";
 import { lyricTypographyVariant } from "./LyricToken";
+import { outline } from "./Outline";
 
 const ChordTypography = withStyles((theme: Theme) => ({
     root: {
@@ -12,8 +13,16 @@ const ChordTypography = withStyles((theme: Theme) => ({
     },
 }))(Typography);
 
+const HighlightedChordBox = withStyles((theme: Theme) => ({
+    root: {
+        ...outline(theme),
+        color: theme.palette.primary.dark,
+    },
+}))(ChordTypography);
+
 interface ChordSymbolProps {
     children: string;
+    highlight?: boolean;
 }
 
 const ChordSymbol: React.FC<ChordSymbolProps> = (
@@ -30,14 +39,17 @@ const ChordSymbol: React.FC<ChordSymbolProps> = (
         return inflateIfEmpty(chord);
     };
 
+    const TypographyComponent =
+        props.highlight === true ? HighlightedChordBox : ChordTypography;
+
     return (
-        <ChordTypography
+        <TypographyComponent
             variant={lyricTypographyVariant} // keep chords and lyrics the same size
             display="inline"
             data-testid="ChordSymbol"
         >
             {formattedChord()}
-        </ChordTypography>
+        </TypographyComponent>
     );
 };
 

--- a/src/components/LyricToken.tsx
+++ b/src/components/LyricToken.tsx
@@ -3,15 +3,9 @@ import { Theme, withStyles, Typography } from "@material-ui/core";
 import { TypographyProps } from "@material-ui/core";
 import { DataTestID } from "../common/DataTestID";
 import { isWhitespace } from "../common/Whitespace";
+import { outline } from "./Outline";
 
 export const lyricTypographyVariant: "h6" = "h6";
-
-export const chordOutline = (theme: Theme) => ({
-    borderStyle: "solid",
-    borderColor: theme.palette.primary.main,
-    borderRadius: "0.3em",
-    borderWidth: "0.075em",
-});
 
 const LyricTypography = withStyles((theme: Theme) => ({
     root: {
@@ -20,7 +14,7 @@ const LyricTypography = withStyles((theme: Theme) => ({
     },
 }))(Typography);
 
-const ChordOutlineTypography = withStyles((theme: Theme) => ({
+const InvisibleTypography = withStyles({
     root: {
         color: "transparent",
         cursor: "pointer",
@@ -29,9 +23,14 @@ const ChordOutlineTypography = withStyles((theme: Theme) => ({
         left: 0,
         top: 0,
         transform: "translate(0%, -115%)",
-        "&:hover": chordOutline(theme),
     },
-}))(LyricTypography);
+})(LyricTypography);
+
+const OutlineTypography = withStyles((theme: Theme) => ({
+    root: {
+        "&:hover": outline(theme),
+    },
+}))(InvisibleTypography);
 
 const lyricTypographyProps = {
     variant: lyricTypographyVariant,
@@ -50,18 +49,29 @@ const HighlightedWordTypography = withStyles((theme: Theme) => ({
     },
 }))(LyricTypography);
 
-interface ChordOutlineBoxProps {
+interface ChordTargetBoxProps {
     children: string;
+    highlightable?: boolean;
     onMouseOver?: (event: React.MouseEvent<HTMLSpanElement>) => void;
     onMouseOut?: (event: React.MouseEvent<HTMLSpanElement>) => void;
     onClick?: (event: React.MouseEvent<HTMLSpanElement>) => void;
 }
 
-export const ChordOutlineBox: React.FC<ChordOutlineBoxProps> = (
-    props: ChordOutlineBoxProps
+export const ChordTargetBox: React.FC<ChordTargetBoxProps> = (
+    props: ChordTargetBoxProps
 ): JSX.Element => {
+    const typographyComponent = (): React.ComponentType<TypographyProps> => {
+        if (props.highlightable === true) {
+            return OutlineTypography;
+        }
+
+        return InvisibleTypography;
+    };
+
+    const TypographyComponent = typographyComponent();
+
     return (
-        <ChordOutlineTypography
+        <TypographyComponent
             onClick={props.onClick}
             onMouseOver={props.onMouseOver}
             onMouseOut={props.onMouseOut}
@@ -69,7 +79,7 @@ export const ChordOutlineBox: React.FC<ChordOutlineBoxProps> = (
             data-testid="ChordEditButton"
         >
             {props.children}
-        </ChordOutlineTypography>
+        </TypographyComponent>
     );
 };
 
@@ -81,16 +91,19 @@ interface LyricTokenProps extends DataTestID {
 const LyricToken: React.FC<LyricTokenProps> = (
     props: LyricTokenProps
 ): JSX.Element => {
-    let TypographyComponent: React.ComponentType<TypographyProps>;
-    if (props.highlight === true) {
-        if (isWhitespace(props.children)) {
-            TypographyComponent = HighlightedSpaceTypography;
-        } else {
-            TypographyComponent = HighlightedWordTypography;
+    const typographyComponent = (): React.ComponentType<TypographyProps> => {
+        if (props.highlight !== true) {
+            return LyricTypography;
         }
-    } else {
-        TypographyComponent = LyricTypography;
-    }
+
+        if (isWhitespace(props.children)) {
+            return HighlightedSpaceTypography;
+        }
+
+        return HighlightedWordTypography;
+    };
+
+    const TypographyComponent = typographyComponent();
 
     return (
         <TypographyComponent

--- a/src/components/Outline.ts
+++ b/src/components/Outline.ts
@@ -1,0 +1,8 @@
+import { Theme } from "@material-ui/core";
+
+export const outline = (theme: Theme) => ({
+    borderStyle: "solid",
+    borderColor: theme.palette.primary.main,
+    borderRadius: "0.3em",
+    borderWidth: "0.075em",
+});

--- a/src/test/chords.test.tsx
+++ b/src/test/chords.test.tsx
@@ -96,7 +96,8 @@ describe("Changing the chord", () => {
             "Line-0",
             "NoneditableLine",
             "Block-1",
-            "ChordSymbol"
+            "TokenBox-0",
+            "ChordEditButton"
         );
 
         expect(chordSymbol).toBeInTheDocument();


### PR DESCRIPTION
Simplifying the code further: All lyric tokens now have an invisible target by which hovering or clicking triggers outlining and chord editing respectively. The special handling for the first token now is whether or not it trips a highlight flag.