### PR TITLE
Prevent interaction with rest of the paper when editing

### DIFF
--- a/src/components/display/ChordSymbol.tsx
+++ b/src/components/display/ChordSymbol.tsx
@@ -1,5 +1,5 @@
-import { Theme, Typography } from "@material-ui/core";
-import { withStyles, StyledComponentProps } from "@material-ui/styles";
+import { Typography } from "@material-ui/core";
+import { StyledComponentProps, withStyles } from "@material-ui/styles";
 import React from "react";
 import { inflateIfEmpty } from "../../common/Whitespace";
 import { lyricTypographyVariant } from "./Lyric";

--- a/src/components/display/ChordSymbol.tsx
+++ b/src/components/display/ChordSymbol.tsx
@@ -4,13 +4,13 @@ import React from "react";
 import { inflateIfEmpty } from "../../common/Whitespace";
 import { lyricTypographyVariant } from "./Lyric";
 
-const ChordTypography = withStyles((theme: Theme) => ({
+const ChordTypography = withStyles({
     root: {
         whiteSpace: "pre",
-        cursor: "pointer",
+        // cursor: "pointer",
         fontFamily: "PoriChord",
     },
-}))(Typography);
+})(Typography);
 
 export interface ChordSymbolProps {
     children: string;

--- a/src/components/display/ChordSymbol.tsx
+++ b/src/components/display/ChordSymbol.tsx
@@ -1,5 +1,5 @@
 import { Theme, Typography } from "@material-ui/core";
-import { withStyles } from "@material-ui/styles";
+import { withStyles, StyledComponentProps } from "@material-ui/styles";
 import React from "react";
 import { inflateIfEmpty } from "../../common/Whitespace";
 import { lyricTypographyVariant } from "./Lyric";
@@ -7,12 +7,11 @@ import { lyricTypographyVariant } from "./Lyric";
 const ChordTypography = withStyles({
     root: {
         whiteSpace: "pre",
-        // cursor: "pointer",
         fontFamily: "PoriChord",
     },
 })(Typography);
 
-export interface ChordSymbolProps {
+export interface ChordSymbolProps extends StyledComponentProps {
     children: string;
     className?: string;
 }
@@ -37,6 +36,7 @@ const ChordSymbol: React.FC<ChordSymbolProps> = (
             display="inline"
             data-testid="ChordSymbol"
             className={props.className}
+            classes={props.classes}
         >
             {formattedChord()}
         </ChordTypography>

--- a/src/components/edit/Block.tsx
+++ b/src/components/edit/Block.tsx
@@ -102,6 +102,8 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
 
             // make this async so that the feedback for the cursor is fast
             setTimeout(() => {
+                // block splitting happens after the first token
+                // as first token is already aligned with the current chord
                 if (tokenIndex !== 0) {
                     props.onBlockSplit?.(props.chordBlock, tokenIndex);
                 }
@@ -170,10 +172,6 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
     );
 
     const chordRow = (): JSX.Element => {
-        //@ts-ignore
-        if (window.debug !== undefined && window.debug) {
-            debugger;
-        }
         if (editing) {
             return (
                 <Box data-testid="ChordEdit">

--- a/src/components/edit/Block.tsx
+++ b/src/components/edit/Block.tsx
@@ -98,18 +98,14 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
         tokenIndex: number
     ) => {
         return (event: React.MouseEvent<HTMLSpanElement>) => {
+            // block splitting happens after the first token
+            // as first token is already aligned with the current chord
+            if (tokenIndex !== 0) {
+                props.onBlockSplit?.(props.chordBlock, tokenIndex);
+            }
+
             setEditing(true);
-
-            // make this async so that the feedback for the cursor is fast
-            setTimeout(() => {
-                // block splitting happens after the first token
-                // as first token is already aligned with the current chord
-                if (tokenIndex !== 0) {
-                    props.onBlockSplit?.(props.chordBlock, tokenIndex);
-                }
-
-                props.onInteractionStart?.();
-            });
+            props.onInteractionStart?.();
 
             event.stopPropagation();
         };

--- a/src/components/edit/Block.tsx
+++ b/src/components/edit/Block.tsx
@@ -18,7 +18,6 @@ import { lyricTypographyVariant } from "../display/Lyric";
 import TextInput from "./TextInput";
 import Token from "./Token";
 import ChordSymbol from "../display/ChordSymbol";
-import ReactDOM from "react-dom";
 
 const chordSymbolClassName = "ChordSymbol";
 
@@ -99,29 +98,25 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
         tokenIndex: number
     ) => {
         return (event: React.MouseEvent<HTMLSpanElement>) => {
-            // ReactDOM.unstable_batchedUpdates(() => {
             setEditing(true);
 
-            // block splitting happens after the first token
-            // as first token is already aligned with the current chord
-            if (tokenIndex !== 0) {
-                props.onBlockSplit?.(props.chordBlock, tokenIndex);
-            }
+            // make this async so that the feedback for the cursor is fast
+            setTimeout(() => {
+                if (tokenIndex !== 0) {
+                    props.onBlockSplit?.(props.chordBlock, tokenIndex);
+                }
 
-            props.onInteractionStart?.();
-            // });
+                props.onInteractionStart?.();
+            });
 
             event.stopPropagation();
         };
     };
 
     const endEdit = (newChord: string) => {
-        // ReactDOM.unstable_batchedUpdates(() => {
         setEditing(false);
-
         props.onChordChange?.(props.chordBlock, newChord);
         props.onInteractionEnd?.();
-        // });
     };
 
     const handleDragged = () => {

--- a/src/components/edit/ChordEditLine.tsx
+++ b/src/components/edit/ChordEditLine.tsx
@@ -49,11 +49,16 @@ const HighlightableBox = withStyles((theme: Theme) => ({
 
 interface ChordEditLineProps {
     chordLine: ChordLine;
+    interactive: boolean;
+
     onEdit?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     onAdd?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     onRemove?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
     onChangeLine?: (id: IDable<"ChordLine">) => void;
     onChordDragAndDrop?: BlockProps["onChordDragAndDrop"];
+
+    onInteractionStart?: () => void;
+    onInteractionEnd?: () => void;
 }
 
 const ChordEditLine: React.FC<ChordEditLineProps> = (
@@ -69,7 +74,11 @@ const ChordEditLine: React.FC<ChordEditLineProps> = (
         ];
     }
 
-    const hoverMenu = (): React.ReactElement => {
+    const hoverMenu = (): React.ReactElement | string => {
+        if (!props.interactive) {
+            return "";
+        }
+
         return (
             <Button onClick={props.onRemove} data-testid={"RemoveButton"}>
                 <BackspaceIcon />
@@ -99,12 +108,15 @@ const ChordEditLine: React.FC<ChordEditLineProps> = (
     const blocks: React.ReactElement[] = chordBlocks.map(
         (chordBlock: ChordBlock, index: number) => (
             <Block
+                interactive={props.interactive}
                 key={chordBlock.id}
                 chordBlock={chordBlock}
                 onChordDragAndDrop={props.onChordDragAndDrop}
                 onChordChange={chordChangeHandler}
                 onBlockSplit={blockSplitHandler}
                 data-testid={`Block-${index}`}
+                onInteractionStart={props.onInteractionStart}
+                onInteractionEnd={props.onInteractionEnd}
             ></Block>
         )
     );

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Paper as UnstyledPaper, withStyles, Grid } from "@material-ui/core";
 import Line from "./Line";
 import { IDable } from "../../common/ChordModel/Collection";
@@ -21,6 +21,10 @@ interface ChordPaperBodyProps {
 const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
     props: ChordPaperBodyProps
 ): React.ReactElement => {
+    const [interacting, setInteracting] = useState(false);
+
+    const interactive = !interacting;
+
     const addLineToTop = () => {
         const newLine: ChordLine = new ChordLine();
         props.song.addBeginning(newLine);
@@ -107,8 +111,11 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
 
                 return [
                     <Line
+                        interactive={interactive}
                         key={line.id}
                         chordLine={line}
+                        onInteractionStart={() => setInteracting(true)}
+                        onInteractionEnd={() => setInteracting(false)}
                         onAddLine={addLine}
                         onRemoveLine={removeLine}
                         onChangeLine={changeLine}
@@ -118,6 +125,7 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
                         data-testid={`Line-${index}`}
                     />,
                     <NewLine
+                        interactive={interactive}
                         key={"NewLine-" + line.id}
                         onAdd={addLineBelow}
                         data-testid={`NewLine-${index}`}
@@ -128,6 +136,7 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
 
         const firstNewLine = (
             <NewLine
+                interactive={interactive}
                 key={"NewLine-Top"}
                 onAdd={addLineToTop}
                 data-testid={"NewLine-Top"}

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -46,6 +46,16 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
         notifySongChanged();
     };
 
+    const handleInteractionStart = () => {
+        // do this async - don't block the interactive element from being responsive
+        // while the rest of the app rerenders
+        (async () => setInteracting(true))();
+    };
+
+    const handleInteractionEnd = () => {
+        (async () => setInteracting(false))();
+    };
+
     const pasteOverflowFromLine = (
         id: IDable<"ChordLine">,
         overflowContent: string[]
@@ -114,8 +124,8 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
                         interactive={interactive}
                         key={line.id}
                         chordLine={line}
-                        onInteractionStart={() => setInteracting(true)}
-                        onInteractionEnd={() => setInteracting(false)}
+                        onInteractionStart={handleInteractionStart}
+                        onInteractionEnd={handleInteractionEnd}
                         onAddLine={addLine}
                         onRemoveLine={removeLine}
                         onChangeLine={changeLine}

--- a/src/components/edit/DraggableChordSymbol.tsx
+++ b/src/components/edit/DraggableChordSymbol.tsx
@@ -2,13 +2,20 @@ import { RootRef } from "@material-ui/core";
 import React from "react";
 import { useDrag } from "react-dnd";
 import { IDable } from "../../common/ChordModel/Collection";
-import ChordSymbol, { ChordSymbolProps } from "../display/ChordSymbol";
+import UnstyledChordSymbol, { ChordSymbolProps } from "../display/ChordSymbol";
 import { NewDNDChord } from "./ChordDroppable";
+import { withStyles } from "@material-ui/styles";
 
 interface DraggableChordSymbolProps extends ChordSymbolProps {
     chordBlockID: IDable<"ChordBlock">;
     onDragged?: () => void;
 }
+
+const ChordSymbol = withStyles({
+    root: {
+        cursor: "pointer",
+    },
+})(UnstyledChordSymbol);
 
 const DraggableChordSymbol: React.FC<DraggableChordSymbolProps> = (
     props: DraggableChordSymbolProps

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -32,20 +32,18 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
     const [removed, setRemoved] = useState(false);
 
     const startEdit = () => {
-        ReactDOM.unstable_batchedUpdates(() => {
+        setEditing(true);
+        setTimeout(() => {
             props.onInteractionStart?.();
-            setEditing(true);
         });
     };
 
     const finishEdit = (newLyrics: string) => {
-        ReactDOM.unstable_batchedUpdates(() => {
-            setEditing(false);
+        setEditing(false);
 
-            props.chordLine.replaceLyrics(newLyrics);
-            props.onChangeLine?.(props.chordLine);
-            props.onInteractionEnd?.();
-        });
+        props.chordLine.replaceLyrics(newLyrics);
+        props.onChangeLine?.(props.chordLine);
+        props.onInteractionEnd?.();
     };
 
     const addHandler = () => {

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -7,7 +7,6 @@ import { lyricTypographyVariant } from "../display/Lyric";
 import { BlockProps } from "./Block";
 import ChordEditLine from "./ChordEditLine";
 import TextInput from "./TextInput";
-import ReactDOM from "react-dom";
 
 interface LineProps extends DataTestID {
     chordLine: ChordLine;

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -32,9 +32,7 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
 
     const startEdit = () => {
         setEditing(true);
-        setTimeout(() => {
-            props.onInteractionStart?.();
-        });
+        props.onInteractionStart?.();
     };
 
     const finishEdit = (newLyrics: string) => {

--- a/src/components/edit/NewLine.tsx
+++ b/src/components/edit/NewLine.tsx
@@ -41,17 +41,30 @@ const AddCircleOutlineIcon = withStyles((theme: Theme) => ({
 
 interface NewLineProps extends DataTestID {
     onAdd?: () => void;
+    interactive: boolean;
 }
 
 const NewLine: React.FC<NewLineProps> = (props: NewLineProps): JSX.Element => {
     const theme: Theme = useTheme();
 
-    const hoverMenu = (): React.ReactElement => {
+    const hoverMenu = (): React.ReactElement | string => {
+        if (!props.interactive) {
+            return "";
+        }
+
         return (
             <Button data-testid={"AddButton"} onClick={props.onAdd}>
                 <AddCircleOutlineIcon />
             </Button>
         );
+    };
+
+    const handleClick = (): (() => void) | undefined => {
+        if (!props.interactive) {
+            return undefined;
+        }
+
+        return props.onAdd;
     };
 
     return (
@@ -60,7 +73,7 @@ const NewLine: React.FC<NewLineProps> = (props: NewLineProps): JSX.Element => {
                 container
                 direction="column"
                 justify="center"
-                onClick={props.onAdd}
+                onClick={handleClick()}
                 data-testid={props["data-testid"]}
                 style={{
                     minHeight: theme.spacing(3),


### PR DESCRIPTION
When editing lyrics/chords, it's possible to highlight and click other areas which gives the impression that this is a valid workflow. Changing it such that there is a global state and only one thing can be interactive at a time.