### PR TITLE
Only one interaction at a time

### DIFF
--- a/src/components/edit/Block.tsx
+++ b/src/components/edit/Block.tsx
@@ -1,7 +1,7 @@
 import { Box, Grid, makeStyles, Theme } from "@material-ui/core";
 import red from "@material-ui/core/colors/red";
 import clsx from "clsx";
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { ChordBlock } from "../../common/ChordModel/ChordBlock";
 import { IDable } from "../../common/ChordModel/Collection";
 import { DataTestID } from "../../common/DataTestID";
@@ -17,6 +17,7 @@ import {
 import { lyricTypographyVariant } from "../display/Lyric";
 import TextInput from "./TextInput";
 import Token from "./Token";
+import { InteractionContext } from "./InteractionContext";
 
 const chordSymbolClassName = "ChordSymbol";
 
@@ -66,6 +67,7 @@ export interface BlockProps extends DataTestID {
 
 const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
     const [editing, setEditing] = useState(false);
+    const { startInteraction, endInteraction } = useContext(InteractionContext);
 
     let lyricTokens: string[] = props.chordBlock.lyricTokens;
 
@@ -99,6 +101,8 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
             }
 
             setEditing(true);
+            startInteraction();
+
             event.stopPropagation();
         };
     };
@@ -128,6 +132,7 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
         }
 
         setEditing(false);
+        endInteraction();
     };
 
     const lyricBlock = (lyric: string, index: number): React.ReactElement => {

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -1,11 +1,23 @@
-import React from "react";
-import { Paper as UnstyledPaper, withStyles, Grid } from "@material-ui/core";
+import React, { useState } from "react";
+import {
+    Paper as UnstyledPaper,
+    withStyles,
+    Grid,
+    makeStyles,
+} from "@material-ui/core";
 import Line from "./Line";
 import { IDable } from "../../common/ChordModel/Collection";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
 import NewLine from "./NewLine";
 import DragAndDrop from "./DragAndDrop";
+import { InteractionContext, InteractionSetter } from "./InteractionContext";
+
+const useUninteractiveStyle = makeStyles({
+    root: {
+        pointerEvents: "none",
+    },
+});
 
 const Paper = withStyles({
     root: {
@@ -21,6 +33,23 @@ interface ChordPaperBodyProps {
 const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
     props: ChordPaperBodyProps
 ): React.ReactElement => {
+    const [interacting, setInteracting] = useState(false);
+
+    const interactionContextValue: InteractionSetter = {
+        startInteraction: () => {
+            setTimeout(() => {
+                setInteracting(true);
+            });
+        },
+        endInteraction: () => {
+            setTimeout(() => {
+                setInteracting(false);
+            });
+        },
+    };
+
+    const uninteractiveStyle = useUninteractiveStyle();
+
     const addLineToTop = () => {
         const newLine: ChordLine = new ChordLine();
         props.song.addBeginning(newLine);
@@ -138,17 +167,22 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
         return lines;
     };
 
+    // prevent other interactions if currently interacting
+    const paperClassName = interacting ? uninteractiveStyle.root : undefined;
+
     return (
         <DragAndDrop>
-            <Paper elevation={0}>
-                <Grid container>
-                    <Grid item xs={1}></Grid>
-                    <Grid item xs={10}>
-                        {lines()}
+            <InteractionContext.Provider value={interactionContextValue}>
+                <Paper className={paperClassName} elevation={0}>
+                    <Grid container>
+                        <Grid item xs={1}></Grid>
+                        <Grid item xs={10}>
+                            {lines()}
+                        </Grid>
+                        <Grid item xs={1}></Grid>
                     </Grid>
-                    <Grid item xs={1}></Grid>
-                </Grid>
-            </Paper>
+                </Paper>
+            </InteractionContext.Provider>
         </DragAndDrop>
     );
 };

--- a/src/components/edit/InteractionContext.ts
+++ b/src/components/edit/InteractionContext.ts
@@ -1,0 +1,15 @@
+import React from "react";
+
+export interface InteractionSetter {
+    startInteraction: () => void;
+    endInteraction: () => void;
+}
+
+const defaultSetter: InteractionSetter = {
+    startInteraction: () => {},
+    endInteraction: () => {},
+};
+
+export const InteractionContext = React.createContext<InteractionSetter>(
+    defaultSetter
+);

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -1,5 +1,5 @@
 import { Box, Slide } from "@material-ui/core";
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { IDable } from "../../common/ChordModel/Collection";
 import { DataTestID } from "../../common/DataTestID";
@@ -7,6 +7,7 @@ import { lyricTypographyVariant } from "../display/Lyric";
 import { BlockProps } from "./Block";
 import ChordEditLine from "./ChordEditLine";
 import TextInput from "./TextInput";
+import { InteractionContext } from "./InteractionContext";
 
 interface LineProps extends DataTestID {
     chordLine: ChordLine;
@@ -25,12 +26,17 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
     const [editing, setEditing] = useState(false);
     const [removed, setRemoved] = useState(false);
 
+    const { startInteraction, endInteraction } = useContext(InteractionContext);
+
     const startEdit = () => {
         setEditing(true);
+        startInteraction();
     };
 
     const finishEdit = (newLyrics: string) => {
         setEditing(false);
+
+        endInteraction();
 
         props.chordLine.replaceLyrics(newLyrics);
 

--- a/src/components/edit/TextInput.tsx
+++ b/src/components/edit/TextInput.tsx
@@ -1,13 +1,19 @@
 import {
     InputBaseComponentProps,
-    TextField,
+    TextField as UnstyledTextField,
     Theme,
     TypographyVariant,
     useTheme,
 } from "@material-ui/core";
 import grey from "@material-ui/core/colors/grey";
-import { CSSProperties } from "@material-ui/styles";
+import { CSSProperties, withStyles } from "@material-ui/styles";
 import React from "react";
+
+const TextField = withStyles({
+    root: {
+        pointerEvents: "auto",
+    },
+})(UnstyledTextField);
 
 interface TextInputProps {
     children: string;


### PR DESCRIPTION
Making the app have only one interaction at a time through disabling pointer events. If any child components start an edit, it flags the interaction state and it would prevent starting any other interactions until the current one is finished.

This was the cause of some user confusion when chord boxes were highlightable while the lyrics were being edited.