### PR TITLE
Use ContentEditable instead of input field

### DIFF
--- a/src/components/display/ChordSymbol.tsx
+++ b/src/components/display/ChordSymbol.tsx
@@ -1,16 +1,16 @@
-import { Theme, Typography } from "@material-ui/core";
+import { Typography } from "@material-ui/core";
 import { withStyles } from "@material-ui/styles";
 import React from "react";
 import { inflateIfEmpty } from "../../common/Whitespace";
 import { lyricTypographyVariant } from "./Lyric";
 
-const ChordTypography = withStyles((theme: Theme) => ({
+const ChordTypography = withStyles({
     root: {
         whiteSpace: "pre",
         cursor: "pointer",
         fontFamily: "PoriChord",
     },
-}))(Typography);
+})(Typography);
 
 export interface ChordSymbolProps {
     children: string;

--- a/src/components/display/Lyric.tsx
+++ b/src/components/display/Lyric.tsx
@@ -1,4 +1,4 @@
-import { Typography, withStyles } from "@material-ui/core";
+import { Typography, withStyles, createStyles } from "@material-ui/core";
 import clsx from "clsx";
 import React from "react";
 import { DataTestID } from "../../common/DataTestID";
@@ -15,14 +15,16 @@ export const lyricTypographyProps = {
     display: "inline" as "inline",
 };
 
-export const LyricTypography = withStyles({
+export const lyricStyle = createStyles({
     root: {
         tabSize: 16,
         whiteSpace: "pre",
         wordSpacing: ".15em",
         display: "inline-block",
     },
-})(Typography);
+});
+
+export const LyricTypography = withStyles(lyricStyle)(Typography);
 
 interface LyricProps extends DataTestID {
     children: string;

--- a/src/components/edit/Block.tsx
+++ b/src/components/edit/Block.tsx
@@ -18,11 +18,21 @@ import { lyricTypographyVariant } from "../display/Lyric";
 import TextInput from "./TextInput";
 import Token from "./Token";
 import { InteractionContext } from "./InteractionContext";
+import { withStyles } from "@material-ui/styles";
 
 const chordSymbolClassName = "ChordSymbol";
 
 const blockChordSymbolClassName = "BlockChordSymbol";
 const blockChordTargetClassName = "BlockChordTarget";
+
+const ChordInput = withStyles((theme: Theme) => ({
+    root: {
+        fontFamily: "PoriChord",
+        borderBottom: "solid",
+        borderBottomColor: theme.palette.secondary.main,
+        borderBottomWidth: "2px",
+    },
+}))(TextInput);
 
 const useFirstTokenStyle = {
     dragOver: makeStyles(
@@ -170,13 +180,13 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
         if (editing) {
             return (
                 <Box data-testid="ChordEdit">
-                    <TextInput
+                    <ChordInput
                         width="5em"
                         variant={lyricTypographyVariant}
                         onFinish={endEdit}
                     >
                         {props.chordBlock.chord}
-                    </TextInput>
+                    </ChordInput>
                 </Box>
             );
         }

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -1,13 +1,22 @@
-import { Box, Slide } from "@material-ui/core";
+import { Box, Slide, withStyles, Theme } from "@material-ui/core";
 import React, { useState, useContext } from "react";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { IDable } from "../../common/ChordModel/Collection";
 import { DataTestID } from "../../common/DataTestID";
-import { lyricTypographyVariant } from "../display/Lyric";
+import { lyricTypographyVariant, lyricStyle } from "../display/Lyric";
 import { BlockProps } from "./Block";
 import ChordEditLine from "./ChordEditLine";
 import TextInput from "./TextInput";
 import { InteractionContext } from "./InteractionContext";
+
+const LyricInput = withStyles((theme: Theme) => ({
+    root: {
+        ...lyricStyle.root,
+        borderBottom: "solid",
+        borderBottomColor: theme.palette.secondary.main,
+        borderBottomWidth: "2px",
+    },
+}))(TextInput);
 
 interface LineProps extends DataTestID {
     chordLine: ChordLine;
@@ -105,14 +114,14 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
 
         return (
             <Box position="absolute" left="0" bottom="2px" width="100%">
-                <TextInput
+                <LyricInput
                     variant={lyricTypographyVariant}
                     onFinish={finishEdit}
                     onPasteOverflow={pasteOverflowHandler}
                     onSpecialBackspace={specialBackspaceHandler}
                 >
                     {lyrics}
-                </TextInput>
+                </LyricInput>
             </Box>
         );
     };

--- a/src/test/chords.test.tsx
+++ b/src/test/chords.test.tsx
@@ -20,7 +20,7 @@ afterEach(cleanup);
 
 beforeAll(() => {
     //https://github.com/mui-org/material-ui/issues/15726#issuecomment-493124813
-    global.document.createRange = () => ({
+    global.document.createRange = (): Range => ({
         setStart: () => {},
         setEnd: () => {},
         //@ts-ignore
@@ -28,7 +28,11 @@ beforeAll(() => {
             nodeName: "BODY",
             ownerDocument: document,
         },
+        selectNodeContents: () => {},
+        collapse: () => {},
     });
+
+    global.window.getSelection = () => null;
 });
 
 const song = (): ChordSong => {
@@ -114,7 +118,7 @@ describe("Changing the chord", () => {
             );
 
         fireEvent.change(await chordEdit(), {
-            target: { value: "F7" },
+            target: { textContent: "F7" },
         });
         enterKey(await chordEdit());
 
@@ -135,7 +139,7 @@ describe("Changing the chord", () => {
         );
 
         fireEvent.change(chordEdit, {
-            target: { value: "" },
+            target: { textContent: "" },
         });
 
         enterKey(chordEdit);
@@ -182,7 +186,7 @@ describe("inserting a chord", () => {
 
     test("it splits the block", async () => {
         fireEvent.change(await chordEdit(), {
-            target: { value: "Am7" },
+            target: { textContent: "Am7" },
         });
 
         enterKey(await chordEdit());
@@ -202,7 +206,7 @@ describe("inserting a chord", () => {
 
     test("it makes no changes if no input after all", async () => {
         fireEvent.change(await chordEdit(), {
-            target: { value: "" },
+            target: { textContent: "" },
         });
 
         enterKey(await chordEdit());

--- a/src/test/lyrics.test.tsx
+++ b/src/test/lyrics.test.tsx
@@ -29,7 +29,7 @@ afterEach(cleanup);
 
 beforeAll(() => {
     //https://github.com/mui-org/material-ui/issues/15726#issuecomment-493124813
-    global.document.createRange = () => ({
+    global.document.createRange = (): Range => ({
         setStart: () => {},
         setEnd: () => {},
         //@ts-ignore
@@ -37,7 +37,11 @@ beforeAll(() => {
             nodeName: "BODY",
             ownerDocument: document,
         },
+        selectNodeContents: () => {},
+        collapse: () => {},
     });
+
+    global.window.getSelection = () => null;
 });
 
 const lyrics: string[] = [
@@ -120,7 +124,7 @@ describe("Plain text edit action", () => {
         expect(await findInputElem()).toBeInTheDocument();
 
         fireEvent.change(await findInputElem(), {
-            target: { value: newLyric },
+            target: { textContent: newLyric },
         });
 
         enterKey(await findInputElem());
@@ -203,7 +207,7 @@ describe("Edit action with chords", () => {
         expect(await findInputElem()).toBeInTheDocument();
 
         fireEvent.change(await findInputElem(), {
-            target: { value: newLyric },
+            target: { textContent: newLyric },
         });
 
         enterKey(await findInputElem());
@@ -552,7 +556,7 @@ describe("Pasting Lyrics", () => {
                         );
 
                     fireEvent.change(await inputElemFn(), {
-                        target: { value: "" },
+                        target: { textContent: "" },
                     });
 
                     await act(async () => {


### PR DESCRIPTION
Changing all text inputs to be contenteditable, with nerfed commands, as text inputs. This allows more control over the styling of the text and lets the editing text more closely resemble the displayed text.