### PR TITLE
Philbug

### DIFF
--- a/src/components/edit/TextInput.tsx
+++ b/src/components/edit/TextInput.tsx
@@ -17,8 +17,10 @@ const InputTypography = withStyles((theme: Theme) => ({
     },
 }))(Typography);
 
-const useSpanStyle = makeStyles({
+const useContentEditableStyle = makeStyles({
     root: {
+        display: "inline-block",
+        width: "100%",
         pointerEvents: "auto",
         outline: "none",
         // this prevent the span height from collapsing if there's no content
@@ -269,7 +271,7 @@ const TextInput: React.FC<TextInputProps> = (
 
     useEffect(focusAndPlaceCaret);
 
-    const spanStyle = useSpanStyle();
+    const spanStyle = useContentEditableStyle();
 
     return (
         <InputTypography


### PR DESCRIPTION
Bug: when clicking the end of the line of the editing lyrics, the edit mode ends.
Expected: cursor goes to the end of the line and edit mode does not end.

Fix is to make the contenteditable full width, so that clicking anywhere along the line still belongs inside the contenteditable, and focus does not escape.