### PR TITLE
Single Line Plain Text Copy bugs

### DIFF
--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -195,7 +195,7 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
         <DragAndDrop>
             <InteractionContext.Provider value={interactionContextValue}>
                 <Paper
-                    onCopy={handleCopy}
+                    onCopy={allowInteraction ? handleCopy : undefined}
                     className={paperClassName}
                     elevation={0}
                 >

--- a/src/components/edit/TextInput.tsx
+++ b/src/components/edit/TextInput.tsx
@@ -143,13 +143,7 @@ const TextInput: React.FC<TextInputProps> = (
         return [beforeSelection, afterSelection];
     };
 
-    const tabHandler = (
-        event: React.KeyboardEvent<HTMLDivElement>
-    ): boolean => {
-        if (event.key !== "Tab") {
-            return false;
-        }
-
+    const insertTextAtSelection = (newContent: string): boolean => {
         if (contentEditableRef.current === null) {
             return false;
         }
@@ -160,11 +154,20 @@ const TextInput: React.FC<TextInputProps> = (
         }
 
         range.deleteContents();
-        range.insertNode(document.createTextNode("\t"));
+        range.insertNode(document.createTextNode(newContent));
         range.collapse(false);
         contentEditableRef.current.normalize();
-
         return true;
+    };
+
+    const tabHandler = (
+        event: React.KeyboardEvent<HTMLDivElement>
+    ): boolean => {
+        if (event.key !== "Tab") {
+            return false;
+        }
+
+        return insertTextAtSelection("\t");
     };
 
     const specialStylingKeysHandler = (
@@ -246,6 +249,10 @@ const TextInput: React.FC<TextInputProps> = (
 
         if (linesOfText.length === 0) {
             return false;
+        }
+
+        if (linesOfText.length === 1) {
+            return insertTextAtSelection(linesOfText[0]);
         }
 
         const [newValue, newPasteLines] = composeMultilinePaste(linesOfText);


### PR DESCRIPTION
A couple issues with single line plain text pasting that wasn't great:
1) copying while in lyric edit mode bubbled to line copy behaviour - it should be more like free form text copying. now the body blocks attaching the copy handler if an interaction is in progress
2) pasting a single line of plain text into the lyric box caused some weird formatting issues due to the contenteditable being copy/pasted. overriding the default behaviour by using existing text insertion methods.