### PR TITLE
Line splitting

### DIFF
--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -19,6 +19,7 @@ import RemoveLine from "./tutorial/RemoveLine";
 import Starting from "./tutorial/Start";
 import Labels from "./tutorial/Labels";
 import PlayMode from "./tutorial/PlayMode";
+import SplitLine from "./tutorial/SplitLine";
 
 type ExerciseEntry = {
     title: string;
@@ -91,6 +92,11 @@ const allExercises: ExerciseEntry[] = [
         title: "Merging Lines",
         route: "/learn/merge_lines",
         component: MergeLine,
+    },
+    {
+        title: "Splitting Lines",
+        route: "/learn/split_lines",
+        component: SplitLine,
     },
     {
         title: "Copying and Pasting Lines",

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -75,7 +75,7 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
         notifySongChanged();
     };
 
-    const handlePasteOverflow = (
+    const handleLyricOverflow = (
         id: IDable<ChordLine>,
         overflowContent: string[]
     ) => {
@@ -159,7 +159,7 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
                         onRemoveLine={handleRemoveLine}
                         onChangeLine={handleChangeLine}
                         onJSONPaste={handleJSONPaste}
-                        onPasteOverflow={handlePasteOverflow}
+                        onLyricOverflow={handleLyricOverflow}
                         onMergeWithPreviousLine={mergeWithPreviousLine}
                         onChordDragAndDrop={handleChordDND}
                         data-testid={`Line-${index}`}

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -39,9 +39,9 @@ interface LineProps extends DataTestID {
     "data-lineid": string;
     onChangeLine?: (id: IDable<ChordLine>) => void;
     onRemoveLine?: (id: IDable<ChordLine>) => void;
-    onPasteOverflow?: (
+    onLyricOverflow?: (
         id: IDable<ChordLine>,
-        overflowPasteContent: string[]
+        overflowLyricContent: string[]
     ) => void;
     onJSONPaste?: (id: IDable<ChordLine>, jsonStr: string) => boolean;
     onMergeWithPreviousLine?: (id: IDable<ChordLine>) => boolean;
@@ -119,7 +119,7 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
             onChangeLine={props.onChangeLine}
             onJSONPaste={props.onJSONPaste}
             onMergeWithPreviousLine={props.onMergeWithPreviousLine}
-            onPasteOverflow={props.onPasteOverflow}
+            onLyricOverflow={props.onLyricOverflow}
         >
             {(startEdit: PlainFn) => withHoverMenu(startEdit, menuItems)}
         </WithLyricInput>

--- a/src/components/edit/TextInput.tsx
+++ b/src/components/edit/TextInput.tsx
@@ -31,7 +31,7 @@ interface TextInputProps extends StyledComponentProps {
     children: string;
     onFinish?: (newValue: string) => void;
     onSpecialBackspace?: PlainFn;
-    onPasteOverflow?: (overflowContent: string[]) => void;
+    onTextOverflow?: (overflowContent: string[]) => void;
     onJSONPaste?: (jsonStr: string) => boolean;
     variant?: TypographyVariant;
 }
@@ -125,6 +125,28 @@ const TextInput: React.FC<TextInputProps> = (
         return true;
     };
 
+    const specialEnterHandler = (
+        event: React.KeyboardEvent<HTMLDivElement>
+    ): boolean => {
+        if (!props.onTextOverflow) {
+            return false;
+        }
+
+        const specialEnter: boolean =
+            event.key === "Enter" && (event.metaKey || event.ctrlKey);
+        if (!specialEnter) {
+            return false;
+        }
+
+        const [beforeSelection, afterSelection] = splitStringBySelection();
+
+        setValue(beforeSelection);
+        finish(beforeSelection);
+
+        props.onTextOverflow([afterSelection]);
+        return true;
+    };
+
     const splitStringBySelection = (): [string, string] => {
         const currValue = value();
 
@@ -187,9 +209,10 @@ const TextInput: React.FC<TextInputProps> = (
         const handlers: ((
             event: React.KeyboardEvent<HTMLDivElement>
         ) => boolean)[] = [
-            enterHandler,
+            specialEnterHandler,
             specialBackspaceHandler,
             tabHandler,
+            enterHandler,
             specialStylingKeysHandler,
         ];
 
@@ -228,7 +251,7 @@ const TextInput: React.FC<TextInputProps> = (
     const handlePlainTextPaste = (
         event: React.ClipboardEvent<HTMLDivElement>
     ): boolean => {
-        if (props.onPasteOverflow === undefined) {
+        if (props.onTextOverflow === undefined) {
             return false;
         }
 
@@ -254,7 +277,7 @@ const TextInput: React.FC<TextInputProps> = (
 
         setValue(newValue);
         finish(newValue);
-        props.onPasteOverflow(newPasteLines);
+        props.onTextOverflow(newPasteLines);
         return true;
     };
 

--- a/src/components/edit/WithLyricInput.tsx
+++ b/src/components/edit/WithLyricInput.tsx
@@ -20,10 +20,7 @@ interface WithLyricInputProps {
     children: (handleEdit: PlainFn) => React.ReactElement;
     chordLine: ChordLine;
     onChangeLine?: (id: IDable<ChordLine>) => void;
-    onPasteOverflow?: (
-        id: IDable<ChordLine>,
-        overflowPasteContent: string[]
-    ) => void;
+    onLyricOverflow?: (id: IDable<ChordLine>, overflowLyric: string[]) => void;
     onJSONPaste?: (id: IDable<ChordLine>, jsonStr: string) => boolean;
     onMergeWithPreviousLine?: (id: IDable<ChordLine>) => boolean;
 }
@@ -43,8 +40,8 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
             props.onChangeLine?.(props.chordLine);
         },
         pasteOverflow: (overflowContent: string[]) => {
-            if (props.onPasteOverflow) {
-                props.onPasteOverflow(props.chordLine, overflowContent);
+            if (props.onLyricOverflow) {
+                props.onLyricOverflow(props.chordLine, overflowContent);
                 finishEdit();
             }
         },
@@ -83,7 +80,7 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
                     variant={lyricTypographyVariant}
                     onFinish={handlers.lyricEdit}
                     onJSONPaste={handlers.jsonPaste}
-                    onPasteOverflow={handlers.pasteOverflow}
+                    onTextOverflow={handlers.pasteOverflow}
                     onSpecialBackspace={handlers.specialBackspace}
                 >
                     {props.chordLine.lyrics}

--- a/src/components/tutorial/SplitLine.tsx
+++ b/src/components/tutorial/SplitLine.tsx
@@ -1,0 +1,64 @@
+import { Typography } from "@material-ui/core";
+import React from "react";
+import { ChordBlock } from "../../common/ChordModel/ChordBlock";
+import { ChordLine } from "../../common/ChordModel/ChordLine";
+import { ChordSong } from "../../common/ChordModel/ChordSong";
+import { LineBreak, LyricsTypography } from "./Common";
+import Playground from "./Playground";
+
+const SplitLine: React.FC<{}> = (): JSX.Element => {
+    const initialSong = new ChordSong([
+        new ChordLine([
+            new ChordBlock({
+                chord: "",
+                lyric: "Why do birds suddenly appear? Every time you are near",
+            }),
+        ]),
+    ]);
+
+    const expectedSong = new ChordSong([
+        new ChordLine([
+            new ChordBlock({
+                chord: "",
+                lyric: "Why do birds suddenly appear? ",
+            }),
+        ]),
+        new ChordLine([
+            new ChordBlock({
+                chord: "",
+                lyric: "Every time you are near",
+            }),
+        ]),
+    ]);
+
+    return (
+        <>
+            <Typography variant="h6">Splitting Lines</Typography>
+            <LineBreak />
+            <Typography>
+                Similarly, we can split lines that may be too long for our chart
+                into two lines. Move the cursor to where you want the line to
+                split, and press
+            </Typography>
+            <Typography>(CTRL+Enter : Windows | CMD+Enter : Mac)</Typography>
+            <LineBreak />
+            <Typography>
+                Right now, chords won't move to the subsequent line - only
+                lyrics will. This can be worked around by dragging and dropping
+                chords after until the feature is cleaned up.
+            </Typography>
+            <LineBreak />
+            <Typography>
+                Let's break the one long line of lyrics up, so that it looks
+                like:
+            </Typography>
+            <LyricsTypography>Why do birds suddenly appear?</LyricsTypography>
+            <LyricsTypography>Every time you are near</LyricsTypography>
+            <LineBreak />
+            <Typography>Try it!</Typography>
+            <Playground initialSong={initialSong} expectedSong={expectedSong} />
+        </>
+    );
+};
+
+export default SplitLine;


### PR DESCRIPTION
Not true line splitting, only lyric splitting.
CTRL/CMD + Enter will split lyrics at the cursor, and push the latter half to a new line. Chords however will not follow and it will simply get moved around as if it was edited...this is a refinement that I may revisit in the future (to move chords when split). The current issue also stands when a lyric paste happens mid line.