### PR TITLE
Play mode: disable smooth scrolling

### DIFF
--- a/src/components/play/PlayContent.tsx
+++ b/src/components/play/PlayContent.tsx
@@ -52,7 +52,6 @@ const PlayContent: React.FC<PlayContentProps> = (
         window.scrollTo({
             left: nextPos,
             top: 0,
-            behavior: "smooth",
         });
     };
 


### PR DESCRIPTION
Based on feedback from Jeff - try disabling smooth scrolling to make the transition instantaneous.