### PR TITLE
Retain login on refresh

### DIFF
--- a/src/components/user/Login.tsx
+++ b/src/components/user/Login.tsx
@@ -136,11 +136,15 @@ const Login: React.FC<LoginProps> = (props: LoginProps): JSX.Element => {
                 setUserInfo(parsed);
             };
 
-            if (shouldShowSigninButton(userInfo)) {
-                const authClient: gapi.auth2.GoogleAuth = gapi.auth2.init({
-                    client_id: googleClientID,
-                    scope: "profile email",
-                });
+            if (!shouldShowSigninButton(userInfo)) {
+                return;
+            }
+
+            const handleAuthInit = (authClient: gapi.auth2.GoogleAuth) => {
+                if (authClient.isSignedIn.get()) {
+                    handleGoogleLogin(authClient.currentUser.get());
+                    return;
+                }
 
                 authClient.attachClickHandler(
                     document.getElementById(googleSignInID),
@@ -153,7 +157,14 @@ const Login: React.FC<LoginProps> = (props: LoginProps): JSX.Element => {
                         );
                     }
                 );
-            }
+            };
+
+            gapi.auth2
+                .init({
+                    client_id: googleClientID,
+                    scope: "profile email",
+                })
+                .then(handleAuthInit);
         });
     }, [enqueueSnackbar, userInfo, setUserInfo]);
 


### PR DESCRIPTION
Right now, refreshing will log the user out even though they were logged in. This is logic that must be handled manually, but more importantly is that gapi.auth2.init returning an auth client is a lie - it firstly returns an uninitialized set of data, but it will return more real data if chained as a promise. wtf.