### PR TITLE
Guard login code depending on gapi loading

### DIFF
--- a/src/components/user/Login.tsx
+++ b/src/components/user/Login.tsx
@@ -83,6 +83,7 @@ type UserInfoState = User | null;
 interface LoginProps extends StyledComponentProps {}
 
 const Login: React.FC<LoginProps> = (props: LoginProps): JSX.Element => {
+    const [gapiLoaded, setGapiLoaded] = useState<boolean>(false);
     const [userInfo, setUserInfo] = useState<UserInfoState>(null);
     const { enqueueSnackbar } = useSnackbar();
     const signinStyles = useSigninStyles();
@@ -94,6 +95,24 @@ const Login: React.FC<LoginProps> = (props: LoginProps): JSX.Element => {
     };
 
     useEffect(() => {
+        if (gapiLoaded) {
+            return;
+        }
+
+        if (window["gapi"] !== undefined) {
+            setGapiLoaded(true);
+        } else {
+            enqueueSnackbar("gapi is not loaded, working offline only", {
+                variant: "error",
+            });
+        }
+    }, [gapiLoaded, enqueueSnackbar]);
+
+    useEffect(() => {
+        if (!gapiLoaded) {
+            return;
+        }
+
         gapi.load("auth2", () => {
             const handleGoogleLogin = async (user: gapi.auth2.GoogleUser) => {
                 const idToken: string = user.getAuthResponse().id_token;
@@ -161,7 +180,11 @@ const Login: React.FC<LoginProps> = (props: LoginProps): JSX.Element => {
                 })
                 .then(handleAuthInit);
         });
-    }, [enqueueSnackbar, userInfo, setUserInfo]);
+    }, [enqueueSnackbar, userInfo, setUserInfo, gapiLoaded]);
+
+    if (!gapiLoaded) {
+        return <div></div>;
+    }
 
     if (shouldShowSigninButton(userInfo)) {
         return (


### PR DESCRIPTION
Right now, if the client is disconnected from the internet, script loading gapi will fail but Login.tsx will continue to try to function as if gapi is there due to the typing, and will cause the whole app to crash - super inconvenient for offline development.. This guards against that code from continuing if gapi is not loaded.