### PR TITLE
adding large tab and remapping keys

### DIFF
--- a/src/common/ChordModel/test/Lyric.test.ts
+++ b/src/common/ChordModel/test/Lyric.test.ts
@@ -56,12 +56,16 @@ describe("lyric tokenizer", () => {
         });
 
         describe("serialized tab", () => {
-            test("size 1", () => {
+            test("small size", () => {
                 expect(new Lyric("<⑴>").isEntirelySpace()).toEqual(true);
             });
 
-            test("size 2", () => {
+            test("medium size", () => {
                 expect(new Lyric("<⑵>").isEntirelySpace()).toEqual(true);
+            });
+
+            test("large size", () => {
+                expect(new Lyric("<⑷>").isEntirelySpace()).toEqual(true);
             });
         });
 
@@ -78,7 +82,7 @@ describe("lyric tokenizer", () => {
         });
 
         test("serialized tab mixed with letters", () => {
-            expect(new Lyric("a<⑵>").isEntirelySpace()).toEqual(false);
+            expect(new Lyric("a<⑷>").isEntirelySpace()).toEqual(false);
         });
     });
 
@@ -227,7 +231,7 @@ describe("lyric tokenizer", () => {
                 });
             });
 
-            test("size 1 tab", () => {
+            test("small tab", () => {
                 const results = tokenize("Never gonna give you up <⑴>");
                 expect(results).toEqual([
                     "Never",
@@ -244,13 +248,29 @@ describe("lyric tokenizer", () => {
                 ]);
             });
 
-            test("size 2 tab", () => {
+            test("medium tab", () => {
                 const results = tokenize("Never gonna<⑵>give you up");
                 expect(results).toEqual([
                     "Never",
                     " ",
                     "gonna",
                     "<⑵>",
+                    "give",
+                    " ",
+                    "you",
+                    " ",
+                    "up",
+                ]);
+            });
+
+            test("large tab", () => {
+                const results = tokenize("<⑷>Never gonna give you up");
+                expect(results).toEqual([
+                    "<⑷>",
+                    "Never",
+                    " ",
+                    "gonna",
+                    " ",
                     "give",
                     " ",
                     "you",

--- a/src/components/edit/lyric_input/SelectionUtils.ts
+++ b/src/components/edit/lyric_input/SelectionUtils.ts
@@ -113,7 +113,6 @@ export const childIndex = (parent: Node, child: Node): number | null => {
     return null;
 };
 
-//todo name
 export const nodeBeforeSelection = (
     ref: React.RefObject<HTMLSpanElement>
 ): Node | null => {

--- a/src/components/edit/lyric_input/useKeyHandler.ts
+++ b/src/components/edit/lyric_input/useKeyHandler.ts
@@ -95,9 +95,11 @@ const tabHandler = (
         let sizedTab: SizedTab;
 
         if (event.shiftKey) {
-            sizedTab = SizedTab.Size2Tab;
+            sizedTab = SizedTab.LargeTab;
+        } else if (event.altKey) {
+            sizedTab = SizedTab.SmallTab;
         } else {
-            sizedTab = SizedTab.Size1Tab;
+            sizedTab = SizedTab.MediumTab;
         }
 
         const domNode = domLyricTab(sizedTab);
@@ -236,16 +238,6 @@ export const useKeyDownHandler = (props: KeyDownHandlerProps) => {
     ];
 
     return (event: React.KeyboardEvent<ContentEditableElement>) => {
-        setTimeout(() => {
-            const selection = document.getSelection();
-            if (selection !== null) {
-                const range = selection.getRangeAt(0);
-                console.log(range.startContainer);
-                console.log(range.startOffset);
-                console.log(range.endOffset);
-            }
-        }, 100);
-
         for (const handler of handlers) {
             const handled: boolean = handler(event);
             if (handled) {

--- a/src/components/lyrics/Tab.tsx
+++ b/src/components/lyrics/Tab.tsx
@@ -7,26 +7,32 @@ export const dataSetTabName = "lyrictabtype";
 export const dataAttributeTabName: "data-lyrictabtype" = "data-lyrictabtype";
 
 export enum SizedTab {
-    Size1Tab = 1,
-    Size2Tab = 2,
+    SmallTab,
+    MediumTab,
+    LargeTab,
 }
 
 export interface LyricTabType {
     sizedTab: SizedTab;
-    serializedStr: "<⑴>" | "<⑵>";
-    [dataAttributeTabName]: "1" | "2";
+    serializedStr: "<⑴>" | "<⑵>" | "<⑷>";
+    [dataAttributeTabName]: "1" | "2" | "4";
 }
 
 export const allTabTypes: LyricTabType[] = [
     {
-        sizedTab: SizedTab.Size1Tab,
+        sizedTab: SizedTab.SmallTab,
         serializedStr: "<⑴>",
         [dataAttributeTabName]: "1",
     },
     {
-        sizedTab: SizedTab.Size2Tab,
+        sizedTab: SizedTab.MediumTab,
         serializedStr: "<⑵>",
         [dataAttributeTabName]: "2",
+    },
+    {
+        sizedTab: SizedTab.LargeTab,
+        serializedStr: "<⑷>",
+        [dataAttributeTabName]: "4",
     },
 ];
 
@@ -84,6 +90,22 @@ const makeSizeStyle = (size: number) => {
     return makeStyles(sizeStyleFn(size));
 };
 
+const makeSizeMap = {
+    [SizedTab.SmallTab]: makeSizeStyle(1),
+    [SizedTab.MediumTab]: makeSizeStyle(2),
+    [SizedTab.LargeTab]: makeSizeStyle(4),
+};
+
+const useSizeMap = () => {
+    // listing explicitly instead of using a loop to let
+    // typescript know the available keys
+    return {
+        [SizedTab.SmallTab]: makeSizeMap[SizedTab.SmallTab](),
+        [SizedTab.MediumTab]: makeSizeMap[SizedTab.MediumTab](),
+        [SizedTab.LargeTab]: makeSizeMap[SizedTab.LargeTab](),
+    };
+};
+
 const makeEditingSizeStyle = (size: number) => {
     const style = sizeStyleFn(size);
 
@@ -99,29 +121,19 @@ const makeEditingSizeStyle = (size: number) => {
     });
 };
 
-const useSize1Style = makeSizeStyle(1);
-const useSize2Style = makeSizeStyle(2);
-
-const useEditingSize1Style = makeEditingSizeStyle(1);
-const useEditingSize2Style = makeEditingSizeStyle(2);
-
-const useSizeMap = () => {
-    const size1Style = useSize1Style();
-    const size2Style = useSize2Style();
-
-    return {
-        [SizedTab.Size1Tab]: size1Style,
-        [SizedTab.Size2Tab]: size2Style,
-    };
+const makeEditingSizeMap = {
+    [SizedTab.SmallTab]: makeEditingSizeStyle(1),
+    [SizedTab.MediumTab]: makeEditingSizeStyle(2),
+    [SizedTab.LargeTab]: makeEditingSizeStyle(4),
 };
 
 const useEditingSizeMap = () => {
-    const size1Style = useEditingSize1Style();
-    const size2Style = useEditingSize2Style();
-
+    // listing explicitly instead of using a loop to let
+    // typescript know the available keys
     return {
-        [SizedTab.Size1Tab]: size1Style,
-        [SizedTab.Size2Tab]: size2Style,
+        [SizedTab.SmallTab]: makeEditingSizeMap[SizedTab.SmallTab](),
+        [SizedTab.MediumTab]: makeEditingSizeMap[SizedTab.MediumTab](),
+        [SizedTab.LargeTab]: makeEditingSizeMap[SizedTab.LargeTab](),
     };
 };
 
@@ -134,7 +146,9 @@ export const useDomLyricTab = (): DomLyricTabFn => {
         const node = document.createElement("span");
         node.className = sizeMap[sizeType].root;
         node.contentEditable = "false";
-        node.dataset[dataSetTabName] = sizeType.toString();
+
+        const tabType = findTabType("sizedTab", sizeType);
+        node.dataset[dataSetTabName] = tabType[dataAttributeTabName];
 
         return node;
     };
@@ -150,12 +164,13 @@ const Tab: React.FC<TabProps> = (props: TabProps): JSX.Element => {
     const editingSizeMap = useEditingSizeMap();
 
     const sizeMap = props.edit ? editingSizeMap : normalSizeMap;
+    const tabType = findTabType("sizedTab", props.type);
 
     return (
         <span
             className={sizeMap[props.type].root}
             contentEditable="false"
-            data-lyrictabtype={props.type.toString()}
+            data-lyrictabtype={tabType[dataAttributeTabName]}
         ></span>
     );
 };

--- a/src/components/tutorial/AddLine.tsx
+++ b/src/components/tutorial/AddLine.tsx
@@ -18,7 +18,7 @@ const AddLine: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑴>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
         ]),
     ]);
 
@@ -32,7 +32,7 @@ const AddLine: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑴>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
         ]),
         new ChordLine([
             new ChordBlock({

--- a/src/components/tutorial/ChordPositioning.tsx
+++ b/src/components/tutorial/ChordPositioning.tsx
@@ -35,7 +35,7 @@ const ChordPositioning: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑴>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
         ]),
     ]);
 
@@ -53,7 +53,7 @@ const ChordPositioning: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑴>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
         ]),
     ]);
 

--- a/src/components/tutorial/Instrumental.tsx
+++ b/src/components/tutorial/Instrumental.tsx
@@ -10,9 +10,9 @@ import Playground from "./Playground";
 const Instrumental: React.FC<{}> = (): JSX.Element => {
     const tabExample = new ChordSong([
         new ChordLine([
-            new ChordBlock({ chord: "Bm", lyric: new Lyric("<⑴>") }),
-            new ChordBlock({ chord: "A", lyric: new Lyric("<⑴>") }),
-            new ChordBlock({ chord: "E", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "Bm", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "A", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "E", lyric: new Lyric("<⑷>") }),
         ]),
     ]);
 
@@ -20,9 +20,9 @@ const Instrumental: React.FC<{}> = (): JSX.Element => {
 
     const expectedSong = new ChordSong([
         new ChordLine([
-            new ChordBlock({ chord: "Bm", lyric: new Lyric("<⑴>") }),
-            new ChordBlock({ chord: "A", lyric: new Lyric("<⑴>") }),
-            new ChordBlock({ chord: "E", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "Bm", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "A", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "E", lyric: new Lyric("<⑷>") }),
         ]),
     ]);
 
@@ -40,19 +40,27 @@ const Instrumental: React.FC<{}> = (): JSX.Element => {
             <Typography>
                 You can do this by hitting{" "}
                 <LyricsTypography display="inline">tab</LyricsTypography> when
-                editting lyrics, for a single sized tab, or{" "}
+                editting lyrics, for a normal sized tab, or{" "}
+                <LyricsTypography display="inline">
+                    ALT/OPTION + tab
+                </LyricsTypography>{" "}
+                for a small sized tab, or{" "}
                 <LyricsTypography display="inline">
                     SHIFT + tab
                 </LyricsTypography>{" "}
-                for a double sized tab.
+                for a large sized tab.
             </Typography>
             <Playground initialSong={tabExample} />
             <LineBreak />
             <Typography>
                 Let's replicate the example from above using{" "}
                 <LyricsTypography display="inline">tab</LyricsTypography>s.
-                Start by editing the lyrics. Insert a Insert two single sized
-                tabs with the tab key, and a double sized tab using shift + tab
+                Start by editing the lyrics. Insert two normal sized tabs with
+                the <LyricsTypography display="inline">tab</LyricsTypography>{" "}
+                key, and a large sized tab using{" "}
+                <LyricsTypography display="inline">
+                    SHIFT + tab
+                </LyricsTypography>{" "}
                 key. Then add{" "}
                 <ChordTypography display="inline">Bm</ChordTypography>,{" "}
                 <ChordTypography display="inline">A</ChordTypography>,{" "}

--- a/src/components/tutorial/Labels.tsx
+++ b/src/components/tutorial/Labels.tsx
@@ -22,7 +22,7 @@ const Labels: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑴>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
         ]),
         new ChordLine([
             new ChordBlock({
@@ -45,7 +45,7 @@ const Labels: React.FC<{}> = (): JSX.Element => {
                 }),
                 new ChordBlock({
                     chord: "B7",
-                    lyric: new Lyric("<⑴>"),
+                    lyric: new Lyric("<⑵>"),
                 }),
             ],
             "Verse"

--- a/src/components/tutorial/PasteLyrics.tsx
+++ b/src/components/tutorial/PasteLyrics.tsx
@@ -18,7 +18,7 @@ const PasteLyrics: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑴>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
         ]),
         new ChordLine(),
     ]);
@@ -33,7 +33,7 @@ const PasteLyrics: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑴>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
         ]),
         new ChordLine([
             new ChordBlock({

--- a/src/components/tutorial/RemoveLine.tsx
+++ b/src/components/tutorial/RemoveLine.tsx
@@ -26,7 +26,7 @@ const RemoveLine: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑴>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
         ]),
         new ChordLine([
             new ChordBlock({
@@ -46,7 +46,7 @@ const RemoveLine: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑴>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
         ]),
     ]);
 

--- a/src/test/chords.test.tsx
+++ b/src/test/chords.test.tsx
@@ -10,7 +10,7 @@ import {
     getExpectChordAndLyric,
     getFindByTestIdChain,
 } from "./matcher";
-import { changeInputText, KeyOptions, pressKey } from "./userEvent";
+import { changeInputText, Keys, pressKey } from "./userEvent";
 
 afterEach(cleanup);
 
@@ -95,7 +95,7 @@ describe("Changing the chord", () => {
 
         changeInputText(await chordEdit(), "F7");
 
-        pressKey(await chordEdit(), KeyOptions.enter);
+        pressKey(await chordEdit(), Keys.enter);
 
         await expectChordAndLyric("F7", "to the moon", [
             "Line-0",
@@ -116,7 +116,7 @@ describe("Changing the chord", () => {
 
         changeInputText(chordEdit, "");
 
-        pressKey(chordEdit, KeyOptions.enter);
+        pressKey(chordEdit, Keys.enter);
 
         await expectChordAndLyric("C", "Fly me to the moon", [
             "Line-0",
@@ -162,7 +162,7 @@ describe("inserting a chord", () => {
     test("it splits the block", async () => {
         changeInputText(await chordEdit(), "Am7");
 
-        pressKey(await chordEdit(), KeyOptions.enter);
+        pressKey(await chordEdit(), Keys.enter);
 
         await expectChordAndLyric("D", "to ", [
             "Line-0",
@@ -180,7 +180,7 @@ describe("inserting a chord", () => {
     test("it makes no changes if no input after all", async () => {
         changeInputText(await chordEdit(), "");
 
-        pressKey(await chordEdit(), KeyOptions.enter);
+        pressKey(await chordEdit(), Keys.enter);
 
         await expectChordAndLyric("D", "to the moon", [
             "Line-0",
@@ -227,7 +227,7 @@ describe("inserting a chord at a tab block", () => {
                     "InnerInput"
                 );
             changeInputText(await chordEdit(), "Am7");
-            pressKey(await chordEdit(), KeyOptions.enter);
+            pressKey(await chordEdit(), Keys.enter);
         };
 
         const insertChordAtLyricAfterTab = async () => {
@@ -252,7 +252,7 @@ describe("inserting a chord at a tab block", () => {
                     "InnerInput"
                 );
             changeInputText(await chordEdit(), "D");
-            pressKey(await chordEdit(), KeyOptions.enter);
+            pressKey(await chordEdit(), Keys.enter);
         };
 
         await insertChordAtTab();

--- a/src/test/lyrics.test.tsx
+++ b/src/test/lyrics.test.tsx
@@ -19,7 +19,7 @@ import {
     lyricsInElement,
     matchLyric,
 } from "./matcher";
-import { changeContentEditableText, KeyOptions, pressKey } from "./userEvent";
+import { changeContentEditableText, Keys, pressKey } from "./userEvent";
 
 afterEach(cleanup);
 
@@ -80,7 +80,7 @@ describe("Plain text edit action", () => {
 
         expect(await findContentEditableElem()).toBeInTheDocument();
         changeContentEditableText(await findContentEditableElem(), newLyric);
-        pressKey(await findContentEditableElem(), KeyOptions.enter);
+        pressKey(await findContentEditableElem(), Keys.enter);
     };
 
     describe("From an empty song", () => {
@@ -167,7 +167,7 @@ describe("Tab spacing", () => {
             test("inserting a tab", async () => {
                 expect(await contentEditableElem()).toBeInTheDocument();
                 action(await contentEditableElem());
-                pressKey(await contentEditableElem(), KeyOptions.enter);
+                pressKey(await contentEditableElem(), Keys.enter);
 
                 await asyncExpectChordAndLyric("", expectedLyrics, [
                     "Line-0",
@@ -177,8 +177,9 @@ describe("Tab spacing", () => {
             });
         };
 
-        describe("size 1 tab", () => {
-            const tabAction = (elem: Element) => pressKey(elem, KeyOptions.tab);
+        describe("small tab", () => {
+            const tabAction = (elem: Element) =>
+                pressKey(elem, Keys.tab, { altKey: true });
 
             testTab(
                 "Put some old bay on it and now it's a crab claw<⑴>",
@@ -186,12 +187,21 @@ describe("Tab spacing", () => {
             );
         });
 
-        describe("size 2 tab", () => {
-            const tabAction = (elem: Element) =>
-                pressKey(elem, KeyOptions.tab, true);
+        describe("medium tab", () => {
+            const tabAction = (elem: Element) => pressKey(elem, Keys.tab);
 
             testTab(
                 "Put some old bay on it and now it's a crab claw<⑵>",
+                tabAction
+            );
+        });
+
+        describe("large tab", () => {
+            const tabAction = (elem: Element) =>
+                pressKey(elem, Keys.tab, { shiftKey: true });
+
+            testTab(
+                "Put some old bay on it and now it's a crab claw<⑷>",
                 tabAction
             );
         });
@@ -202,21 +212,21 @@ describe("Tab spacing", () => {
             const insertTab = async () => {
                 await clickFirstLine();
                 expect(await contentEditableElem()).toBeInTheDocument();
-                pressKey(await contentEditableElem(), KeyOptions.tab);
-                pressKey(await contentEditableElem(), KeyOptions.enter);
+                pressKey(await contentEditableElem(), Keys.tab);
+                pressKey(await contentEditableElem(), Keys.enter);
             };
 
             const backspaceTab = async () => {
                 await clickFirstLine();
                 expect(await contentEditableElem()).toBeInTheDocument();
-                pressKey(await contentEditableElem(), KeyOptions.backspace);
-                pressKey(await contentEditableElem(), KeyOptions.enter);
+                pressKey(await contentEditableElem(), Keys.backspace);
+                pressKey(await contentEditableElem(), Keys.enter);
             };
 
             await insertTab();
             await asyncExpectChordAndLyric(
                 "",
-                "Put some old bay on it and now it's a crab claw<⑴>",
+                "Put some old bay on it and now it's a crab claw<⑵>",
                 ["Line-0", "NoneditableLine", "Block-0"]
             );
 
@@ -233,14 +243,7 @@ describe("Tab spacing", () => {
         const insertTab = async () => {
             await clickFirstLine();
             expect(await contentEditableElem()).toBeInTheDocument();
-            pressKey(await contentEditableElem(), KeyOptions.tab);
-        };
-
-        const backspaceTab = async () => {
-            await clickFirstLine();
-            expect(await contentEditableElem()).toBeInTheDocument();
-            pressKey(await contentEditableElem(), KeyOptions.backspace);
-            pressKey(await contentEditableElem(), KeyOptions.enter);
+            pressKey(await contentEditableElem(), Keys.tab);
         };
 
         await insertTab();
@@ -263,7 +266,7 @@ describe("Tab spacing", () => {
         expect(beforeNavigationRange.startOffset).toEqual(2);
         expect(beforeNavigationRange.endOffset).toEqual(2);
 
-        pressKey(await contentEditableElem(), KeyOptions.left);
+        pressKey(await contentEditableElem(), Keys.left);
 
         const afterLeftNavigationRange = selection.getRangeAt(0);
         expect(afterLeftNavigationRange.startContainer).toEqual(
@@ -276,7 +279,7 @@ describe("Tab spacing", () => {
         expect(afterLeftNavigationRange.startOffset).toEqual(1);
         expect(afterLeftNavigationRange.endOffset).toEqual(1);
 
-        pressKey(await contentEditableElem(), KeyOptions.right);
+        pressKey(await contentEditableElem(), Keys.right);
 
         const afterRightNavigationRange = selection.getRangeAt(0);
         expect(afterRightNavigationRange.startContainer).toEqual(
@@ -328,7 +331,7 @@ describe("Edit action with chords", () => {
 
         changeContentEditableText(await findInputElem(), newLyric);
 
-        pressKey(await findInputElem(), KeyOptions.enter);
+        pressKey(await findInputElem(), Keys.enter);
     };
 
     describe("no op", () => {

--- a/src/test/userEvent.ts
+++ b/src/test/userEvent.ts
@@ -1,14 +1,16 @@
 import { fireEvent } from "@testing-library/react";
 import { act } from "react-dom/test-utils";
 
-type KeyOption = typeof fireEvent.keyDown extends (
-    arg1: any,
-    args: infer U
-) => any
+type Key = typeof fireEvent.keyDown extends (arg1: any, args: infer U) => any
     ? U
     : never;
 
-export const KeyOptions = {
+type KeyOption = {
+    shiftKey?: boolean;
+    altKey?: boolean;
+};
+
+export const Keys = {
     enter: {
         key: "Enter",
         keyCode: 13,
@@ -38,18 +40,18 @@ export const KeyOptions = {
 
 export const pressKey = (
     element: Element,
-    keyOptions: KeyOption,
-    shift?: boolean
+    key: Key,
+    option?: KeyOption
 ): void => {
-    const key = {
-        shiftKey: shift,
-        ...keyOptions,
+    const eventKey = {
+        ...option,
+        ...key,
     };
 
     act(() => {
-        fireEvent.keyDown(element, key);
-        fireEvent.keyPress(element, key);
-        fireEvent.keyUp(element, key);
+        fireEvent.keyDown(element, eventKey);
+        fireEvent.keyPress(element, eventKey);
+        fireEvent.keyUp(element, eventKey);
     });
 };
 


### PR DESCRIPTION
Brief usability tests show that medium (size 2) tabs are the most frequently desired size, so mapping default tab to that and turning size 1/small to ALT/OPTION + tab, also adding in large tab as SHIFT + tab.