### PR TITLE
Patch orphaned blocks with tabs instead of spaces

### DIFF
--- a/src/common/ChordModel/test/ChordLinePatcher.test.ts
+++ b/src/common/ChordModel/test/ChordLinePatcher.test.ts
@@ -214,11 +214,11 @@ describe("ChordLinePatcher", () => {
             });
         });
 
-        test("removing the first block, causing it to be replaced with a string", () => {
+        test("removing the first block, causing it to be replaced with a tab", () => {
             replaceChordLineLyrics(chordLine, new Lyric("that I'm in trouble"));
             expect(chordLine.elements[0]).toMatchObject({
                 chord: "F",
-                lyric: new Lyric(" "),
+                lyric: new Lyric("<⑴>"),
             });
             expect(chordLine.elements[1]).toMatchObject({
                 chord: "C",
@@ -226,15 +226,15 @@ describe("ChordLinePatcher", () => {
             });
         });
 
-        test("removing the second block, causing it to steal a space from the first", () => {
+        test("removing the second block, causing it to replaced with a tab", () => {
             replaceChordLineLyrics(chordLine, new Lyric("It's your fault "));
             expect(chordLine.elements[0]).toMatchObject({
                 chord: "F",
-                lyric: new Lyric("It's your fault"),
+                lyric: new Lyric("It's your fault "),
             });
             expect(chordLine.elements[1]).toMatchObject({
                 chord: "C",
-                lyric: new Lyric(" "),
+                lyric: new Lyric("<⑴>"),
             });
         });
     });

--- a/src/test/lyrics.test.tsx
+++ b/src/test/lyrics.test.tsx
@@ -9,7 +9,6 @@ import { ChordBlock } from "../common/ChordModel/ChordBlock";
 import { ChordLine } from "../common/ChordModel/ChordLine";
 import { ChordSong } from "../common/ChordModel/ChordSong";
 import { Lyric } from "../common/ChordModel/Lyric";
-import { contentEditableElement } from "../components/edit/lyric_input/SelectionUtils";
 import { chordPaperFromLyrics, chordPaperFromSong } from "./common";
 import {
     ExpectChordAndLyricFn,
@@ -507,10 +506,10 @@ describe("Edit action with chords", () => {
             ]);
         });
 
-        test("removing the first block, causing it to be replaced with a space", async () => {
+        test("removing the first block, causing it to be replaced with a tab", async () => {
             await changeLyric("that I'm in trouble");
 
-            await expectChordAndLyric("F", " ", [
+            await expectChordAndLyric("F", "<⑴>", [
                 "Line-0",
                 "NoneditableLine",
                 "Block-0",
@@ -523,7 +522,7 @@ describe("Edit action with chords", () => {
             ]);
         });
 
-        test("removing the second block, causing it to steal a space from the first", async () => {
+        test("removing the second block, causing it to be replaced with a tab", async () => {
             await changeLyric("It's your fault");
 
             await expectChordAndLyric("F", "It's your fault", [
@@ -532,7 +531,7 @@ describe("Edit action with chords", () => {
                 "Block-0",
             ]);
 
-            await expectChordAndLyric("C", " ", [
+            await expectChordAndLyric("C", "<⑴>", [
                 "Line-0",
                 "NoneditableLine",
                 "Block-1",


### PR DESCRIPTION
When blocks are orphaned due to not having any lyrics, fill the empty block with a small tab instead of a space - when blocks are just spaces they're super painful to deal with and having something chonkier like a tab makes the lyric editing process a lot more ergonomic.