### PR TITLE
Change serialized tabs to private unicode chars

### DIFF
--- a/src/assets/songs/never_gonna_give_you_up_plastic_love.json
+++ b/src/assets/songs/never_gonna_give_you_up_plastic_love.json
@@ -4,37 +4,27 @@
             "elements": [
                 {
                     "chord": "G^",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "<⑴>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Em7",
-                    "lyric": {
-                        "serializedLyric": "<⑴>|"
-                    },
+                    "lyric": { "serializedLyric": "|" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7b13/D",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "C13",
-                    "lyric": {
-                        "serializedLyric": "<⑵>|"
-                    },
+                    "lyric": { "serializedLyric": "|" },
                     "type": "ChordBlock"
                 }
             ],
@@ -45,23 +35,17 @@
             "elements": [
                 {
                     "chord": "G^",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>|"
-                    },
+                    "lyric": { "serializedLyric": "|" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "B7",
-                    "lyric": {
-                        "serializedLyric": "<⑵><⑵>|"
-                    },
+                    "lyric": { "serializedLyric": "|" },
                     "type": "ChordBlock"
                 }
             ],
@@ -71,30 +55,22 @@
             "elements": [
                 {
                     "chord": "Em7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>|"
-                    },
+                    "lyric": { "serializedLyric": "|" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>|"
-                    },
+                    "lyric": { "serializedLyric": "|" },
                     "type": "ChordBlock"
                 }
             ],
@@ -104,30 +80,22 @@
             "elements": [
                 {
                     "chord": "Em7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>|"
-                    },
+                    "lyric": { "serializedLyric": "|" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>|"
-                    },
+                    "lyric": { "serializedLyric": "|" },
                     "type": "ChordBlock"
                 }
             ],
@@ -137,16 +105,12 @@
             "elements": [
                 {
                     "chord": "Em7",
-                    "lyric": {
-                        "serializedLyric": "We're no strangers to "
-                    },
+                    "lyric": { "serializedLyric": "We're no strangers to " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "love"
-                    },
+                    "lyric": { "serializedLyric": "love" },
                     "type": "ChordBlock"
                 }
             ],
@@ -157,16 +121,12 @@
             "elements": [
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "You know the rules and "
-                    },
+                    "lyric": { "serializedLyric": "You know the rules and " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "so do I"
-                    },
+                    "lyric": { "serializedLyric": "so do I" },
                     "type": "ChordBlock"
                 }
             ],
@@ -183,9 +143,7 @@
                 },
                 {
                     "chord": "C7",
-                    "lyric": {
-                        "serializedLyric": "thinking of"
-                    },
+                    "lyric": { "serializedLyric": "thinking of" },
                     "type": "ChordBlock"
                 }
             ],
@@ -202,9 +160,7 @@
                 },
                 {
                     "chord": "E7",
-                    "lyric": {
-                        "serializedLyric": "any other guy"
-                    },
+                    "lyric": { "serializedLyric": "any other guy" },
                     "type": "ChordBlock"
                 }
             ],
@@ -214,23 +170,17 @@
             "elements": [
                 {
                     "chord": "Em7",
-                    "lyric": {
-                        "serializedLyric": "I just wanna "
-                    },
+                    "lyric": { "serializedLyric": "I just wanna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "tell you how I'm feeling"
-                    },
+                    "lyric": { "serializedLyric": "tell you how I'm feeling" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 }
             ],
@@ -240,16 +190,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Gotta make you "
-                    },
+                    "lyric": { "serializedLyric": "Gotta make you " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "understand"
-                    },
+                    "lyric": { "serializedLyric": "understand" },
                     "type": "ChordBlock"
                 }
             ],
@@ -259,16 +205,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Em9",
-                    "lyric": {
-                        "serializedLyric": "give you up"
-                    },
+                    "lyric": { "serializedLyric": "give you up" },
                     "type": "ChordBlock"
                 }
             ],
@@ -279,16 +221,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "let you down"
-                    },
+                    "lyric": { "serializedLyric": "let you down" },
                     "type": "ChordBlock"
                 }
             ],
@@ -298,23 +236,17 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "run around and de-"
-                    },
+                    "lyric": { "serializedLyric": "run around and de-" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "sert you"
-                    },
+                    "lyric": { "serializedLyric": "sert you" },
                     "type": "ChordBlock"
                 }
             ],
@@ -324,16 +256,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Em9",
-                    "lyric": {
-                        "serializedLyric": "make you cry"
-                    },
+                    "lyric": { "serializedLyric": "make you cry" },
                     "type": "ChordBlock"
                 }
             ],
@@ -343,16 +271,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "say goodbye"
-                    },
+                    "lyric": { "serializedLyric": "say goodbye" },
                     "type": "ChordBlock"
                 }
             ],
@@ -362,23 +286,17 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "tell a lie and "
-                    },
+                    "lyric": { "serializedLyric": "tell a lie and " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "hurt you"
-                    },
+                    "lyric": { "serializedLyric": "hurt you" },
                     "type": "ChordBlock"
                 }
             ],
@@ -388,16 +306,12 @@
             "elements": [
                 {
                     "chord": "Em7",
-                    "lyric": {
-                        "serializedLyric": "We've known each other"
-                    },
+                    "lyric": { "serializedLyric": "We've known each other" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "C7",
-                    "lyric": {
-                        "serializedLyric": " for so long"
-                    },
+                    "lyric": { "serializedLyric": " for so long" },
                     "type": "ChordBlock"
                 }
             ],
@@ -415,9 +329,7 @@
                 },
                 {
                     "chord": "E7",
-                    "lyric": {
-                        "serializedLyric": "you're too shy to say it"
-                    },
+                    "lyric": { "serializedLyric": "you're too shy to say it" },
                     "type": "ChordBlock"
                 }
             ],
@@ -434,9 +346,7 @@
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "going on"
-                    },
+                    "lyric": { "serializedLyric": "going on" },
                     "type": "ChordBlock"
                 }
             ],
@@ -453,23 +363,17 @@
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": " gon-"
-                    },
+                    "lyric": { "serializedLyric": " gon-" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7/C#",
-                    "lyric": {
-                        "serializedLyric": "na "
-                    },
+                    "lyric": { "serializedLyric": "na " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "D7",
-                    "lyric": {
-                        "serializedLyric": "play it"
-                    },
+                    "lyric": { "serializedLyric": "play it" },
                     "type": "ChordBlock"
                 }
             ],
@@ -479,23 +383,17 @@
             "elements": [
                 {
                     "chord": "G",
-                    "lyric": {
-                        "serializedLyric": "And if you "
-                    },
+                    "lyric": { "serializedLyric": "And if you " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A",
-                    "lyric": {
-                        "serializedLyric": "ask me how I'm feeling"
-                    },
+                    "lyric": { "serializedLyric": "ask me how I'm feeling" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "G",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 }
             ],
@@ -505,16 +403,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Don't tell me you're too "
-                    },
+                    "lyric": { "serializedLyric": "Don't tell me you're too " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A",
-                    "lyric": {
-                        "serializedLyric": "blind to see"
-                    },
+                    "lyric": { "serializedLyric": "blind to see" },
                     "type": "ChordBlock"
                 }
             ],
@@ -524,23 +418,17 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "C#m11",
-                    "lyric": {
-                        "serializedLyric": "give you "
-                    },
+                    "lyric": { "serializedLyric": "give you " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#7",
-                    "lyric": {
-                        "serializedLyric": "up"
-                    },
+                    "lyric": { "serializedLyric": "up" },
                     "type": "ChordBlock"
                 }
             ],
@@ -551,16 +439,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "let you down"
-                    },
+                    "lyric": { "serializedLyric": "let you down" },
                     "type": "ChordBlock"
                 }
             ],
@@ -570,37 +454,27 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "G",
-                    "lyric": {
-                        "serializedLyric": "run a-"
-                    },
+                    "lyric": { "serializedLyric": "run a-" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A",
-                    "lyric": {
-                        "serializedLyric": "round and de-"
-                    },
+                    "lyric": { "serializedLyric": "round and de-" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "sert you"
-                    },
+                    "lyric": { "serializedLyric": "sert you" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 }
             ],
@@ -610,30 +484,22 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "G^",
-                    "lyric": {
-                        "serializedLyric": "run a-"
-                    },
+                    "lyric": { "serializedLyric": "run a-" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "round and de-"
-                    },
+                    "lyric": { "serializedLyric": "round and de-" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "B7",
-                    "lyric": {
-                        "serializedLyric": "sert you"
-                    },
+                    "lyric": { "serializedLyric": "sert you" },
                     "type": "ChordBlock"
                 }
             ],
@@ -643,30 +509,22 @@
             "elements": [
                 {
                     "chord": "Em7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "C7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>|"
-                    },
+                    "lyric": { "serializedLyric": "|" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "E7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>|"
-                    },
+                    "lyric": { "serializedLyric": "|" },
                     "type": "ChordBlock"
                 }
             ],
@@ -684,9 +542,7 @@
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 }
             ],
@@ -703,23 +559,17 @@
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": " "
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7/C#",
-                    "lyric": {
-                        "serializedLyric": " "
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "D7",
-                    "lyric": {
-                        "serializedLyric": " "
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 }
             ],
@@ -729,16 +579,12 @@
             "elements": [
                 {
                     "chord": "G",
-                    "lyric": {
-                        "serializedLyric": "We've known each other "
-                    },
+                    "lyric": { "serializedLyric": "We've known each other " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A",
-                    "lyric": {
-                        "serializedLyric": "for so long"
-                    },
+                    "lyric": { "serializedLyric": "for so long" },
                     "type": "ChordBlock"
                 }
             ],
@@ -756,9 +602,7 @@
                 },
                 {
                     "chord": "A",
-                    "lyric": {
-                        "serializedLyric": "you're too shy to say it"
-                    },
+                    "lyric": { "serializedLyric": "you're too shy to say it" },
                     "type": "ChordBlock"
                 }
             ],
@@ -768,23 +612,17 @@
             "elements": [
                 {
                     "chord": "C#m7",
-                    "lyric": {
-                        "serializedLyric": "Inside we "
-                    },
+                    "lyric": { "serializedLyric": "Inside we " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#7",
-                    "lyric": {
-                        "serializedLyric": "both know what's been"
-                    },
+                    "lyric": { "serializedLyric": "both know what's been" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": " going on"
-                    },
+                    "lyric": { "serializedLyric": " going on" },
                     "type": "ChordBlock"
                 }
             ],
@@ -794,30 +632,22 @@
             "elements": [
                 {
                     "chord": "G",
-                    "lyric": {
-                        "serializedLyric": "We know the "
-                    },
+                    "lyric": { "serializedLyric": "We know the " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A",
-                    "lyric": {
-                        "serializedLyric": "game and we're"
-                    },
+                    "lyric": { "serializedLyric": "game and we're" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": " gonna "
-                    },
+                    "lyric": { "serializedLyric": " gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "play it"
-                    },
+                    "lyric": { "serializedLyric": "play it" },
                     "type": "ChordBlock"
                 }
             ],
@@ -827,23 +657,17 @@
             "elements": [
                 {
                     "chord": "G",
-                    "lyric": {
-                        "serializedLyric": "I just wanna "
-                    },
+                    "lyric": { "serializedLyric": "I just wanna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A",
-                    "lyric": {
-                        "serializedLyric": "tell you how I'm feeling"
-                    },
+                    "lyric": { "serializedLyric": "tell you how I'm feeling" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "G",
-                    "lyric": {
-                        "serializedLyric": "<⑵>"
-                    },
+                    "lyric": { "serializedLyric": "" },
                     "type": "ChordBlock"
                 }
             ],
@@ -853,16 +677,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Gotta make you"
-                    },
+                    "lyric": { "serializedLyric": "Gotta make you" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A",
-                    "lyric": {
-                        "serializedLyric": " understand"
-                    },
+                    "lyric": { "serializedLyric": " understand" },
                     "type": "ChordBlock"
                 }
             ],
@@ -872,30 +692,22 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "G^",
-                    "lyric": {
-                        "serializedLyric": "give you "
-                    },
+                    "lyric": { "serializedLyric": "give you " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "up and de-"
-                    },
+                    "lyric": { "serializedLyric": "up and de-" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "B7",
-                    "lyric": {
-                        "serializedLyric": "sert you"
-                    },
+                    "lyric": { "serializedLyric": "sert you" },
                     "type": "ChordBlock"
                 }
             ],
@@ -905,16 +717,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Em9",
-                    "lyric": {
-                        "serializedLyric": "give you up"
-                    },
+                    "lyric": { "serializedLyric": "give you up" },
                     "type": "ChordBlock"
                 }
             ],
@@ -925,16 +733,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "let you down"
-                    },
+                    "lyric": { "serializedLyric": "let you down" },
                     "type": "ChordBlock"
                 }
             ],
@@ -944,23 +748,17 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "run around and de-"
-                    },
+                    "lyric": { "serializedLyric": "run around and de-" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "sert you"
-                    },
+                    "lyric": { "serializedLyric": "sert you" },
                     "type": "ChordBlock"
                 }
             ],
@@ -970,16 +768,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Em9",
-                    "lyric": {
-                        "serializedLyric": "make you cry"
-                    },
+                    "lyric": { "serializedLyric": "make you cry" },
                     "type": "ChordBlock"
                 }
             ],
@@ -989,16 +783,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "say goodbye"
-                    },
+                    "lyric": { "serializedLyric": "say goodbye" },
                     "type": "ChordBlock"
                 }
             ],
@@ -1008,23 +798,17 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "tell a lie and "
-                    },
+                    "lyric": { "serializedLyric": "tell a lie and " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "hurt you"
-                    },
+                    "lyric": { "serializedLyric": "hurt you" },
                     "type": "ChordBlock"
                 }
             ],
@@ -1034,16 +818,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Em9",
-                    "lyric": {
-                        "serializedLyric": "give you up"
-                    },
+                    "lyric": { "serializedLyric": "give you up" },
                     "type": "ChordBlock"
                 }
             ],
@@ -1053,16 +833,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "let you down"
-                    },
+                    "lyric": { "serializedLyric": "let you down" },
                     "type": "ChordBlock"
                 }
             ],
@@ -1072,23 +848,17 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "run around and de-"
-                    },
+                    "lyric": { "serializedLyric": "run around and de-" },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "sert you"
-                    },
+                    "lyric": { "serializedLyric": "sert you" },
                     "type": "ChordBlock"
                 }
             ],
@@ -1098,16 +868,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Em9",
-                    "lyric": {
-                        "serializedLyric": "make you cry"
-                    },
+                    "lyric": { "serializedLyric": "make you cry" },
                     "type": "ChordBlock"
                 }
             ],
@@ -1117,16 +883,12 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "A7",
-                    "lyric": {
-                        "serializedLyric": "say goodbye"
-                    },
+                    "lyric": { "serializedLyric": "say goodbye" },
                     "type": "ChordBlock"
                 }
             ],
@@ -1136,23 +898,17 @@
             "elements": [
                 {
                     "chord": "",
-                    "lyric": {
-                        "serializedLyric": "Never gonna "
-                    },
+                    "lyric": { "serializedLyric": "Never gonna " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "F#m7",
-                    "lyric": {
-                        "serializedLyric": "tell a lie and "
-                    },
+                    "lyric": { "serializedLyric": "tell a lie and " },
                     "type": "ChordBlock"
                 },
                 {
                     "chord": "Bm7",
-                    "lyric": {
-                        "serializedLyric": "hurt you..."
-                    },
+                    "lyric": { "serializedLyric": "hurt you..." },
                     "type": "ChordBlock"
                 }
             ],

--- a/src/common/ChordModel/test/ChordLinePatcher.test.ts
+++ b/src/common/ChordModel/test/ChordLinePatcher.test.ts
@@ -218,7 +218,7 @@ describe("ChordLinePatcher", () => {
             replaceChordLineLyrics(chordLine, new Lyric("that I'm in trouble"));
             expect(chordLine.elements[0]).toMatchObject({
                 chord: "F",
-                lyric: new Lyric("<⑴>"),
+                lyric: new Lyric("\ue100"),
             });
             expect(chordLine.elements[1]).toMatchObject({
                 chord: "C",
@@ -234,7 +234,7 @@ describe("ChordLinePatcher", () => {
             });
             expect(chordLine.elements[1]).toMatchObject({
                 chord: "C",
-                lyric: new Lyric("<⑴>"),
+                lyric: new Lyric("\ue100"),
             });
         });
     });

--- a/src/common/ChordModel/test/Lyric.test.ts
+++ b/src/common/ChordModel/test/Lyric.test.ts
@@ -57,24 +57,24 @@ describe("lyric tokenizer", () => {
 
         describe("serialized tab", () => {
             test("small size", () => {
-                expect(new Lyric("<⑴>").isEntirelySpace()).toEqual(true);
+                expect(new Lyric("\ue100").isEntirelySpace()).toEqual(true);
             });
 
             test("medium size", () => {
-                expect(new Lyric("<⑵>").isEntirelySpace()).toEqual(true);
+                expect(new Lyric("\ue200").isEntirelySpace()).toEqual(true);
             });
 
             test("large size", () => {
-                expect(new Lyric("<⑷>").isEntirelySpace()).toEqual(true);
+                expect(new Lyric("\ue400").isEntirelySpace()).toEqual(true);
             });
         });
 
         test("mixed space and serialized tab", () => {
-            expect(new Lyric(" <⑴>").isEntirelySpace()).toEqual(false);
+            expect(new Lyric(" \ue100").isEntirelySpace()).toEqual(false);
         });
 
         test("multiple serialized tab", () => {
-            expect(new Lyric("<⑵><⑵>").isEntirelySpace()).toEqual(false);
+            expect(new Lyric("\ue200\ue200").isEntirelySpace()).toEqual(false);
         });
 
         test("space mixed with letters", () => {
@@ -82,7 +82,7 @@ describe("lyric tokenizer", () => {
         });
 
         test("serialized tab mixed with letters", () => {
-            expect(new Lyric("a<⑷>").isEntirelySpace()).toEqual(false);
+            expect(new Lyric("a\ue400").isEntirelySpace()).toEqual(false);
         });
     });
 
@@ -175,64 +175,8 @@ describe("lyric tokenizer", () => {
         });
 
         describe("serialized tabs", () => {
-            describe("broken/invalid tabs", () => {
-                test("Missing starting tag", () => {
-                    const results = tokenize("Never gonna give you up ⑴>");
-                    expect(results).toEqual([
-                        "Never",
-                        " ",
-                        "gonna",
-                        " ",
-                        "give",
-                        " ",
-                        "you",
-                        " ",
-                        "up",
-                        " ",
-                        "⑴",
-                        ">",
-                    ]);
-                });
-
-                test("Missing ending tag", () => {
-                    const results = tokenize("Never gonna give you up <⑴");
-                    expect(results).toEqual([
-                        "Never",
-                        " ",
-                        "gonna",
-                        " ",
-                        "give",
-                        " ",
-                        "you",
-                        " ",
-                        "up",
-                        " ",
-                        "<",
-                        "⑴",
-                    ]);
-                });
-
-                test("Missing enclosed content", () => {
-                    const results = tokenize("Never gonna give you up <>");
-                    expect(results).toEqual([
-                        "Never",
-                        " ",
-                        "gonna",
-                        " ",
-                        "give",
-                        " ",
-                        "you",
-                        " ",
-                        "up",
-                        " ",
-                        "<",
-                        ">",
-                    ]);
-                });
-            });
-
             test("small tab", () => {
-                const results = tokenize("Never gonna give you up <⑴>");
+                const results = tokenize("Never gonna give you up \ue100");
                 expect(results).toEqual([
                     "Never",
                     " ",
@@ -244,17 +188,17 @@ describe("lyric tokenizer", () => {
                     " ",
                     "up",
                     " ",
-                    "<⑴>",
+                    "\ue100",
                 ]);
             });
 
             test("medium tab", () => {
-                const results = tokenize("Never gonna<⑵>give you up");
+                const results = tokenize("Never gonna\ue200give you up");
                 expect(results).toEqual([
                     "Never",
                     " ",
                     "gonna",
-                    "<⑵>",
+                    "\ue200",
                     "give",
                     " ",
                     "you",
@@ -264,9 +208,9 @@ describe("lyric tokenizer", () => {
             });
 
             test("large tab", () => {
-                const results = tokenize("<⑷>Never gonna give you up");
+                const results = tokenize("\ue400Never gonna give you up");
                 expect(results).toEqual([
-                    "<⑷>",
+                    "\ue400",
                     "Never",
                     " ",
                     "gonna",

--- a/src/components/lyrics/Tab.tsx
+++ b/src/components/lyrics/Tab.tsx
@@ -14,24 +14,24 @@ export enum SizedTab {
 
 export interface LyricTabType {
     sizedTab: SizedTab;
-    serializedStr: "<⑴>" | "<⑵>" | "<⑷>";
+    serializedStr: "\ue100" | "\ue200" | "\ue400";
     [dataAttributeTabName]: "1" | "2" | "4";
 }
 
 export const allTabTypes: LyricTabType[] = [
     {
         sizedTab: SizedTab.SmallTab,
-        serializedStr: "<⑴>",
+        serializedStr: "\ue100",
         [dataAttributeTabName]: "1",
     },
     {
         sizedTab: SizedTab.MediumTab,
-        serializedStr: "<⑵>",
+        serializedStr: "\ue200",
         [dataAttributeTabName]: "2",
     },
     {
         sizedTab: SizedTab.LargeTab,
-        serializedStr: "<⑷>",
+        serializedStr: "\ue400",
         [dataAttributeTabName]: "4",
     },
 ];

--- a/src/components/tutorial/AddLine.tsx
+++ b/src/components/tutorial/AddLine.tsx
@@ -18,7 +18,7 @@ const AddLine: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("\ue200") }),
         ]),
     ]);
 
@@ -32,7 +32,7 @@ const AddLine: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("\ue200") }),
         ]),
         new ChordLine([
             new ChordBlock({

--- a/src/components/tutorial/ChordPositioning.tsx
+++ b/src/components/tutorial/ChordPositioning.tsx
@@ -35,7 +35,7 @@ const ChordPositioning: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("\ue200") }),
         ]),
     ]);
 
@@ -53,7 +53,7 @@ const ChordPositioning: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("\ue200") }),
         ]),
     ]);
 

--- a/src/components/tutorial/Instrumental.tsx
+++ b/src/components/tutorial/Instrumental.tsx
@@ -10,9 +10,9 @@ import Playground from "./Playground";
 const Instrumental: React.FC<{}> = (): JSX.Element => {
     const tabExample = new ChordSong([
         new ChordLine([
-            new ChordBlock({ chord: "Bm", lyric: new Lyric("<⑵>") }),
-            new ChordBlock({ chord: "A", lyric: new Lyric("<⑵>") }),
-            new ChordBlock({ chord: "E", lyric: new Lyric("<⑷>") }),
+            new ChordBlock({ chord: "Bm", lyric: new Lyric("\ue200") }),
+            new ChordBlock({ chord: "A", lyric: new Lyric("\ue200") }),
+            new ChordBlock({ chord: "E", lyric: new Lyric("\ue400") }),
         ]),
     ]);
 
@@ -20,9 +20,9 @@ const Instrumental: React.FC<{}> = (): JSX.Element => {
 
     const expectedSong = new ChordSong([
         new ChordLine([
-            new ChordBlock({ chord: "Bm", lyric: new Lyric("<⑵>") }),
-            new ChordBlock({ chord: "A", lyric: new Lyric("<⑵>") }),
-            new ChordBlock({ chord: "E", lyric: new Lyric("<⑷>") }),
+            new ChordBlock({ chord: "Bm", lyric: new Lyric("\ue200") }),
+            new ChordBlock({ chord: "A", lyric: new Lyric("\ue200") }),
+            new ChordBlock({ chord: "E", lyric: new Lyric("\ue400") }),
         ]),
     ]);
 

--- a/src/components/tutorial/Labels.tsx
+++ b/src/components/tutorial/Labels.tsx
@@ -22,7 +22,7 @@ const Labels: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("\ue200") }),
         ]),
         new ChordLine([
             new ChordBlock({
@@ -45,7 +45,7 @@ const Labels: React.FC<{}> = (): JSX.Element => {
                 }),
                 new ChordBlock({
                     chord: "B7",
-                    lyric: new Lyric("<⑵>"),
+                    lyric: new Lyric("\ue200"),
                 }),
             ],
             "Verse"

--- a/src/components/tutorial/PasteLyrics.tsx
+++ b/src/components/tutorial/PasteLyrics.tsx
@@ -18,7 +18,7 @@ const PasteLyrics: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("\ue200") }),
         ]),
         new ChordLine(),
     ]);
@@ -33,7 +33,7 @@ const PasteLyrics: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("\ue200") }),
         ]),
         new ChordLine([
             new ChordBlock({

--- a/src/components/tutorial/RemoveLine.tsx
+++ b/src/components/tutorial/RemoveLine.tsx
@@ -26,7 +26,7 @@ const RemoveLine: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("\ue200") }),
         ]),
         new ChordLine([
             new ChordBlock({
@@ -46,7 +46,7 @@ const RemoveLine: React.FC<{}> = (): JSX.Element => {
                 chord: "B7sus4",
                 lyric: new Lyric("pear?"),
             }),
-            new ChordBlock({ chord: "B7", lyric: new Lyric("<⑵>") }),
+            new ChordBlock({ chord: "B7", lyric: new Lyric("\ue200") }),
         ]),
     ]);
 

--- a/src/test/chords.test.tsx
+++ b/src/test/chords.test.tsx
@@ -197,7 +197,7 @@ describe("inserting a chord at a tab block", () => {
     beforeEach(async () => {
         const { findByTestId } = render(
             chordPaperFromLyrics([
-                "I<⑵>never loved you fully in the way I could",
+                "I\ue200never loved you fully in the way I could",
             ])
         );
         findByTestIdChain = getFindByTestIdChain(findByTestId);
@@ -264,7 +264,7 @@ describe("inserting a chord at a tab block", () => {
             "Block-0",
         ]);
 
-        await expectChordAndLyric("Am7", "<⑵>", [
+        await expectChordAndLyric("Am7", "\ue200", [
             "Line-0",
             "NoneditableLine",
             "Block-1",

--- a/src/test/lyrics.test.tsx
+++ b/src/test/lyrics.test.tsx
@@ -181,7 +181,7 @@ describe("Tab spacing", () => {
                 pressKey(elem, Keys.tab, { altKey: true });
 
             testTab(
-                "Put some old bay on it and now it's a crab claw<⑴>",
+                "Put some old bay on it and now it's a crab claw\ue100",
                 tabAction
             );
         });
@@ -190,7 +190,7 @@ describe("Tab spacing", () => {
             const tabAction = (elem: Element) => pressKey(elem, Keys.tab);
 
             testTab(
-                "Put some old bay on it and now it's a crab claw<⑵>",
+                "Put some old bay on it and now it's a crab claw\ue200",
                 tabAction
             );
         });
@@ -200,7 +200,7 @@ describe("Tab spacing", () => {
                 pressKey(elem, Keys.tab, { shiftKey: true });
 
             testTab(
-                "Put some old bay on it and now it's a crab claw<⑷>",
+                "Put some old bay on it and now it's a crab claw\ue400",
                 tabAction
             );
         });
@@ -225,7 +225,7 @@ describe("Tab spacing", () => {
             await insertTab();
             await asyncExpectChordAndLyric(
                 "",
-                "Put some old bay on it and now it's a crab claw<⑵>",
+                "Put some old bay on it and now it's a crab claw\ue200",
                 ["Line-0", "NoneditableLine", "Block-0"]
             );
 
@@ -509,7 +509,7 @@ describe("Edit action with chords", () => {
         test("removing the first block, causing it to be replaced with a tab", async () => {
             await changeLyric("that I'm in trouble");
 
-            await expectChordAndLyric("F", "<⑴>", [
+            await expectChordAndLyric("F", "\ue100", [
                 "Line-0",
                 "NoneditableLine",
                 "Block-0",
@@ -531,7 +531,7 @@ describe("Edit action with chords", () => {
                 "Block-0",
             ]);
 
-            await expectChordAndLyric("C", "<⑴>", [
+            await expectChordAndLyric("C", "\ue100", [
                 "Line-0",
                 "NoneditableLine",
                 "Block-1",


### PR DESCRIPTION
Turns out having <stuff> tags were a bad idea - specifically for the lyric differ which can only treat each character separately, and therefore there are cases where the diff can result in a broken tag despite normal user input.

Switching small, medium, large tabs to U+E100, U+E200, and U+E400 (reserved private chars) respectively, which can only be processed atomically.