### PR TITLE
Revert "Play mode: disable smooth scrolling"

### DIFF
--- a/src/components/play/PlayContent.tsx
+++ b/src/components/play/PlayContent.tsx
@@ -52,6 +52,7 @@ const PlayContent: React.FC<PlayContentProps> = (
         window.scrollTo({
             left: nextPos,
             top: 0,
+            behavior: "smooth",
         });
     };
 


### PR DESCRIPTION
Was bad design decision, reverting. Not seeing the animation disorients the user from keeping track of where is where.