### PR TITLE
LastSavedAt gets discarded upon any change to the song

### DIFF
--- a/src/common/ChordModel/ChordSong.ts
+++ b/src/common/ChordModel/ChordSong.ts
@@ -194,9 +194,7 @@ export class ChordSong extends Collection<ChordLine>
 
     clone(): ChordSong {
         return new ChordSong(this.elements, {
-            id: this.id,
-            owner: this.owner,
-            metadata: this.metadata,
+            ...this,
         });
     }
 


### PR DESCRIPTION
During cloning, the lastSavedAt wasn't copied over because errors of omission are difficult to catch. Using the spread operator to make sure everything is captured.