### PR TITLE
Hide menus that the user can't use unless signed in

### DIFF
--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -28,7 +28,7 @@ import { demoPath, songPath } from "../common/paths";
 import LoadSongDialog from "./LoadSongDialog";
 import { allExerciseRoutes, ExerciseRoute } from "./Tutorial";
 import Login from "./user/Login";
-import { User } from "./user/userContext";
+import { User, UserContext } from "./user/userContext";
 
 const withPointerStyle = withStyles({
     root: {
@@ -91,6 +91,7 @@ interface SideMenuProps {
 const SideMenu: React.FC<SideMenuProps> = (
     props: SideMenuProps
 ): JSX.Element => {
+    const user = React.useContext(UserContext);
     const [expanded, setExpanded] = useState(false);
     const [showLoadSongsDialog, setShowLoadSongsDialog] = useState(false);
 
@@ -201,19 +202,23 @@ const SideMenu: React.FC<SideMenuProps> = (
                         />
                     </ListItem>
                 </Link>
-                <ListItem
-                    key="Load Song"
-                    button
-                    onClick={(event: unknown) => setShowLoadSongsDialog(true)}
-                >
-                    <ListItemIcon>
-                        <LibraryMusicIcon />
-                    </ListItemIcon>
-                    <ListItemText
-                        primary="Load Song"
-                        primaryTypographyProps={typographyProps}
-                    />
-                </ListItem>
+                {user !== null && (
+                    <ListItem
+                        key="Load Song"
+                        button
+                        onClick={(event: unknown) =>
+                            setShowLoadSongsDialog(true)
+                        }
+                    >
+                        <ListItemIcon>
+                            <LibraryMusicIcon />
+                        </ListItemIcon>
+                        <ListItemText
+                            primary="Load Song"
+                            primaryTypographyProps={typographyProps}
+                        />
+                    </ListItem>
+                )}
                 <Link
                     key={demoPath.URL()}
                     to={demoPath.URL()}

--- a/src/components/edit/menu/ChordPaperMenu.tsx
+++ b/src/components/edit/menu/ChordPaperMenu.tsx
@@ -19,6 +19,7 @@ import { useLoadMenuAction } from "./load";
 import { useSaveMenuAction } from "./save";
 import TransposeMenu from "./TransposeMenu";
 import useKonamiCode from "react-use-konami";
+import { UserContext } from "../../user/userContext";
 
 interface ChordPaperMenuProps {
     song: ChordSong;
@@ -41,6 +42,8 @@ const ChordPaperMenu: React.FC<ChordPaperMenuProps> = (
     const [transposeMenuOpen, setTransposeMenuOpen] = useState(false);
     const [offlineMode, setOfflineMode] = useState(false);
     const { enqueueSnackbar } = useSnackbar();
+
+    const user = React.useContext(UserContext);
     const loadAction = useLoadMenuAction(props.onSongChanged, enqueueSnackbar);
     const saveAction = useSaveMenuAction(props.song);
     const cloudSaveAction = useCloudCreateSong(props.song);
@@ -102,11 +105,11 @@ const ChordPaperMenu: React.FC<ChordPaperMenuProps> = (
                     setTransposeMenuOpen(true);
                 }}
             />
-            {props.song.isUnsaved() && (
+            {props.song.isUnsaved() && user !== null && (
                 <SpeedDialAction
                     icon={<CloudUploadIcon />}
                     tooltipTitle="Save to Cloud"
-                    onClick={cloudSaveAction}
+                    onClick={() => cloudSaveAction(user)}
                 />
             )}
             <SpeedDialAction

--- a/src/components/edit/menu/cloudSave.ts
+++ b/src/components/edit/menu/cloudSave.ts
@@ -1,14 +1,12 @@
 import { isLeft } from "fp-ts/lib/These";
 import { useSnackbar } from "notistack";
-import React from "react";
 import { useHistory } from "react-router-dom";
 import { createSong } from "../../../common/backend";
-import { songPath } from "../../../common/paths";
-import { User, UserContext } from "../../user/userContext";
 import { ChordSong } from "../../../common/ChordModel/ChordSong";
+import { songPath } from "../../../common/paths";
+import { User } from "../../user/userContext";
 
 export const useCloudCreateSong = (song: ChordSong) => {
-    const user = React.useContext(UserContext);
     const { enqueueSnackbar } = useSnackbar();
     const history = useHistory();
 
@@ -48,14 +46,7 @@ export const useCloudCreateSong = (song: ChordSong) => {
         );
     };
 
-    return async () => {
-        if (user === null) {
-            enqueueSnackbar("You must log in to save your song", {
-                variant: "error",
-            });
-            return;
-        }
-
+    return async (user: User) => {
         if (song.isUnsaved()) {
             await createNewSong(user);
         }


### PR DESCRIPTION
Some menu items just don't work unless the user is signed in, so hide them unless they're signed in to prevent confusion.