### PR TITLE
Refresh Google auth token when expired

### DIFF
--- a/src/common/ChordModel/ChordSong.ts
+++ b/src/common/ChordModel/ChordSong.ts
@@ -230,7 +230,7 @@ export class ChordSong extends Collection<ChordLine>
             return false;
         }
 
-        return this.owner === user.user_id;
+        return this.owner === user.userID;
     }
 
     mergeLineWithPrevious(idable: IDable<ChordLine>): boolean {

--- a/src/components/LoadSongDialog.tsx
+++ b/src/components/LoadSongDialog.tsx
@@ -69,10 +69,7 @@ const LoadSongDialog: React.FC<LoadSongsDialogProps> = (
     };
 
     const loadSummaries = async () => {
-        const result = await getSongsForUser(
-            user.user_id,
-            user.google_auth_token
-        );
+        const result = await getSongsForUser(user.userID, user.authToken);
         if (isLeft(result)) {
             setFetchState({ state: "error", error: result.left });
             return;

--- a/src/components/WithCloud.tsx
+++ b/src/components/WithCloud.tsx
@@ -55,7 +55,7 @@ export const withCloud = <P extends SongProps>(
 
                 dirty = false;
 
-                const result = await updateSong(song, user.google_auth_token);
+                const result = await updateSong(song, user.authToken);
                 if (isLeft(result)) {
                     //TODO: expose more error detail
                     showError("Failed to auto save the song");

--- a/src/components/edit/menu/cloudSave.ts
+++ b/src/components/edit/menu/cloudSave.ts
@@ -11,9 +11,9 @@ export const useCloudCreateSong = (song: ChordSong) => {
     const history = useHistory();
 
     const createNewSong = async (user: User) => {
-        song.owner = user.user_id;
+        song.owner = user.userID;
 
-        const createResult = await createSong(song, user.google_auth_token);
+        const createResult = await createSong(song, user.authToken);
 
         if (isLeft(createResult)) {
             console.error(


### PR DESCRIPTION
When the user logs in, we retain the auth/id token for the purposes of authorizing and authenticating, but the token's only valid for 1 hour. If the user works for over an hour on the app, then requests will start failing.