### PR TITLE
adding env that allows set-env

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -25,6 +25,8 @@ jobs:
               run: bash git-version.sh
             - name: Get version tag from GIT-VERSION-FILE
               run: echo "::set-env name=gitver::$(cat GIT-VERSION-FILE)"
+              env:
+                  ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
             - name: Login to DockerHub
               run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
             - name: Build image w/version

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -22,6 +22,8 @@ jobs:
 
             - name: Get version tag from GIT-VERSION-FILE
               run: echo "::set-env name=gitver::$(cat GIT-VERSION-FILE)"
+              env:
+                  ACTIONS_ALLOW_UNSECURE_COMMANDS: "true"
 
             - name: Install Dependencies
               run: yarn


### PR DESCRIPTION
There's a vulnerability that prevents the use of set-env - the right way to do this is via something called environment files but the biggest risk would just be the version number being hijacked - a fairly minor thing so override for now until there's bandwidth to fix.