### PR TITLE
Fill empty columns in play mode

### DIFF
--- a/src/components/edit/menu/ChordPaperMenu.tsx
+++ b/src/components/edit/menu/ChordPaperMenu.tsx
@@ -39,9 +39,10 @@ const SpeedDial = withStyles((theme: Theme) => ({
 const ChordPaperMenu: React.FC<ChordPaperMenuProps> = (
     props: ChordPaperMenuProps
 ): JSX.Element => {
+    const developmentEnv = process.env.NODE_ENV === "development";
     const [open, setOpen] = useState(false);
     const [transposeMenuOpen, setTransposeMenuOpen] = useState(false);
-    const [offlineMode, setOfflineMode] = useState(false);
+    const [offlineMode, setOfflineMode] = useState(developmentEnv);
     const { enqueueSnackbar } = useSnackbar();
 
     const user = React.useContext(UserContext);

--- a/src/components/play/DisplaySettingsDialog.tsx
+++ b/src/components/play/DisplaySettingsDialog.tsx
@@ -49,7 +49,7 @@ const DisplaySettingsDialog: React.FC<DisplaySettingsDialogProps> = (
     props: DisplaySettingsDialogProps
 ): JSX.Element => {
     const [settings, setSettings] = useState<TextSettings>({
-        numberOfColumns: props.defaultSettings.numberOfColumns.toString(),
+        numberOfColumns: props.defaultSettings.numberOfColumnsPerPage.toString(),
         fontSize: props.defaultSettings.fontSize.toString(),
         columnMargin: props.defaultSettings.columnMargin.toString(),
     });
@@ -106,7 +106,7 @@ const DisplaySettingsDialog: React.FC<DisplaySettingsDialogProps> = (
         }
 
         const displaySettings: DisplaySettings = {
-            numberOfColumns: numberOfColumnsResults.right,
+            numberOfColumnsPerPage: numberOfColumnsResults.right,
             fontSize: fontSizeResults.right,
             columnMargin: columnMarginResults.right,
         };
@@ -126,7 +126,7 @@ const DisplaySettingsDialog: React.FC<DisplaySettingsDialogProps> = (
         }
 
         props.onSubmit?.({
-            numberOfColumns: settings.right.numberOfColumns,
+            numberOfColumnsPerPage: settings.right.numberOfColumnsPerPage,
             fontSize: settings.right.fontSize,
             columnMargin: settings.right.columnMargin,
         });

--- a/src/components/play/Play.tsx
+++ b/src/components/play/Play.tsx
@@ -16,7 +16,7 @@ interface PlayProps {
 
 const Play: React.FC<PlayProps> = (props: PlayProps): JSX.Element => {
     const [displaySettings, setDisplaySettings] = useState<DisplaySettings>({
-        numberOfColumns: 2,
+        numberOfColumnsPerPage: 2,
         fontSize: 14,
         columnMargin: 20,
     });

--- a/src/components/play/PlayLine.tsx
+++ b/src/components/play/PlayLine.tsx
@@ -26,7 +26,7 @@ const PlayLine: React.FC<PlayLineProps> = (
     let lineComponent: React.ReactElement = (
         <Box>
             {props.chordLine.chordBlocks.map((block: ChordBlock) => (
-                <PlayBlock block={block}></PlayBlock>
+                <PlayBlock block={block} key={block.id}></PlayBlock>
             ))}
         </Box>
     );


### PR DESCRIPTION
In play mode, navigation to the last page can be confusing if there aren't enough columns to fill the page, and the scroll will be less than one page width.

e.g., Suppose in a 3 column layout, there's enough content for 4 columns - a, b, c, d
the first page will be `a | b | c`
but the scroll to the second page will look like `b | c | d`
This is particularly bad if the song is repetitive and the user expects the left side to be where to start reading again, only to read content they already played past.

This change pads the end with enough empty columns so that the next page flows immediately after:
e.g. `a | b | c`, then `d | [empty] | [empty]`
