### PR TITLE
Command/Ctrl Chord Drag and Drop

### DIFF
--- a/src/components/edit/Block.tsx
+++ b/src/components/edit/Block.tsx
@@ -71,7 +71,8 @@ export interface BlockProps extends DataTestID {
         destinationBlockID: IDable<ChordBlock>,
         splitIndex: number,
         newChord: string,
-        sourceBlockID: IDable<ChordBlock>
+        sourceBlockID: IDable<ChordBlock>,
+        copyAction: boolean
     ) => void;
     onChordChange?: (id: IDable<ChordBlock>, newChord: string) => void;
     onBlockSplit?: (id: IDable<ChordBlock>, splitIndex: number) => void;
@@ -118,28 +119,27 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
     };
 
     const handleDragged = () => {
-        if (props.onChordChange) {
-            props.onChordChange(props.chordBlock, "");
-        }
+        props.onChordChange?.(props.chordBlock, "");
     };
 
     const dropHandler = (tokenIndex: number) => {
-        return (newChord: string, sourceBlockID: IDable<ChordBlock>) => {
-            if (props.onChordDragAndDrop) {
-                props.onChordDragAndDrop(
-                    props.chordBlock,
-                    tokenIndex,
-                    newChord,
-                    sourceBlockID
-                );
-            }
+        return (
+            newChord: string,
+            sourceBlockID: IDable<ChordBlock>,
+            copyAction: boolean
+        ) => {
+            props.onChordDragAndDrop?.(
+                props.chordBlock,
+                tokenIndex,
+                newChord,
+                sourceBlockID,
+                copyAction
+            );
         };
     };
 
     const endEdit = (newChord: string) => {
-        if (props.onChordChange) {
-            props.onChordChange(props.chordBlock, newChord);
-        }
+        props.onChordChange?.(props.chordBlock, newChord);
 
         finishEdit();
     };

--- a/src/components/edit/ChordDroppable.tsx
+++ b/src/components/edit/ChordDroppable.tsx
@@ -29,9 +29,62 @@ interface ClassNameable {
     className?: string;
 }
 
+interface ChordDropTargetProps {
+    children: (isOver: boolean) => React.ReactElement<ClassNameable>;
+    onDropped: ChordDroppableProps["onDropped"];
+}
+
+interface DropResult {
+    isOver: boolean;
+}
+
+const ChordDropTarget: React.FC<ChordDropTargetProps> = (
+    props: ChordDropTargetProps
+) => {
+    const [{ isOver }, dropRef] = useDrop<DNDChord, DNDChord, DropResult>({
+        accept: DNDChordType,
+        drop: (droppedChord: DNDChord, monitor: DropTargetMonitor) => {
+            const dropResult = monitor.getDropResult();
+
+            // the drop effect (i.e. move vs copy) can only be retrieved from the drop result,
+            // which is the object that is returned by this fn (drop), with dropEffect shimmed in
+            //
+            // the drop result is always null the first time and therefore the drop effect cannot be
+            // retrieved on the first interception of the drop event
+            //
+            // this handler is meant to be called twice - the first time where drop result is null
+            // and the second time where drop result is not null, and the drop effect can be found
+            //
+            // this code is coupled with the returned component below, where two nested <ChordDropTarget>s are returned
+            // to induce a valid drop result
+            if (dropResult !== null && !droppedChord.handled) {
+                droppedChord.handled = true;
+                const isCopyAction: boolean = dropResult.dropEffect === "copy";
+
+                props.onDropped(
+                    droppedChord.chord,
+                    droppedChord.sourceBlockID,
+                    isCopyAction
+                );
+            }
+
+            return droppedChord;
+        },
+        collect: (monitor: DropTargetMonitor): DropResult => ({
+            isOver: monitor.isOver({ shallow: true }),
+        }),
+    });
+
+    return <RootRef rootRef={dropRef}>{props.children(isOver)}</RootRef>;
+};
+
 interface ChordDroppableProps {
     children: React.ReactElement<ClassNameable>;
-    onDropped: (newChord: string, sourceBlockID: IDable<ChordBlock>) => void;
+    onDropped: (
+        newChord: string,
+        sourceBlockID: IDable<ChordBlock>,
+        copyAction: boolean
+    ) => void;
     hoverableClassName?: string;
     dragOverClassName?: string;
 }
@@ -39,32 +92,34 @@ interface ChordDroppableProps {
 const ChordDroppable: React.FC<ChordDroppableProps> = (
     props: ChordDroppableProps
 ) => {
-    const [{ isOver }, dropRef] = useDrop<DNDChord, DNDChord, any>({
-        accept: DNDChordType,
-        drop: (droppedChord: DNDChord) => {
-            if (!droppedChord.handled) {
-                droppedChord.handled = true;
-                props.onDropped(droppedChord.chord, droppedChord.sourceBlockID);
-            }
-            return droppedChord;
-        },
-        collect: (monitor: DropTargetMonitor) => ({
-            isOver: monitor.isOver({ shallow: true }),
-        }),
-    });
+    const childrenWithClassname = (
+        isOver: boolean
+    ): React.ReactElement<ClassNameable> => {
+        let childElem: React.ReactElement<ClassNameable> = props.children;
+        const childClassName: string | undefined = isOver
+            ? props.dragOverClassName
+            : props.hoverableClassName;
 
-    let childElem: React.ReactElement<ClassNameable> = props.children;
-    const childClassName: string | undefined = isOver
-        ? props.dragOverClassName
-        : props.hoverableClassName;
+        if (childClassName !== undefined) {
+            childElem = React.cloneElement(childElem, {
+                className: childClassName,
+            });
+        }
 
-    if (childClassName !== undefined) {
-        childElem = React.cloneElement(childElem, {
-            className: childClassName,
-        });
-    }
+        return childElem;
+    };
 
-    return <RootRef rootRef={dropRef}>{childElem}</RootRef>;
+    return (
+        // nested drop targets to get a drop result -
+        // see the drop handler in ChordDropTarget for a thorough explanation
+        <ChordDropTarget {...props}>
+            {() => (
+                <ChordDropTarget {...props}>
+                    {childrenWithClassname}
+                </ChordDropTarget>
+            )}
+        </ChordDropTarget>
+    );
 };
 
 export default ChordDroppable;

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -124,27 +124,31 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
     };
 
     const notifySongChanged = () => {
-        if (props.onSongChanged) {
-            props.onSongChanged(props.song);
-        }
+        props.onSongChanged?.(props.song);
     };
 
     const handleChordDND = (
         destinationBlockID: IDable<ChordBlock>,
         splitIndex: number,
         newChord: string,
-        sourceBlockID: IDable<ChordBlock>
+        sourceBlockID: IDable<ChordBlock>,
+        copyAction: boolean
     ) => {
-        // clearing the source block first allows handling of when the chord
-        // is dropped onto another token in the same block without special cases
         const [sourceLine, sourceBlock] = props.song.findLineAndBlock(
             sourceBlockID
         );
-        sourceBlock.chord = "";
+
+        const moveAction = !copyAction;
+        if (moveAction) {
+            // clearing the source block first allows handling of when the chord
+            // is dropped onto another token in the same block without special cases
+            sourceBlock.chord = "";
+        }
 
         const [destinationLine, destinationBlock] = props.song.findLineAndBlock(
             destinationBlockID
         );
+
         if (splitIndex !== 0) {
             destinationLine.splitBlock(destinationBlockID, splitIndex);
         }

--- a/src/components/edit/DragAndDrop.tsx
+++ b/src/components/edit/DragAndDrop.tsx
@@ -2,7 +2,59 @@ import React, { useRef } from "react";
 import { createDndContext, DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
-const RNDContext = createDndContext(HTML5Backend);
+// extremely hacky - overriding the implementation of the backend forcibly
+// however React-DND is pretty much unmaintained, so there are few other choices
+export const HTML5BackendWithCTRLKey = (
+    ...params: Parameters<typeof HTML5Backend>
+) => {
+    const backend = HTML5Backend(...params);
+
+    const welpThingsBroke = () => {
+        console.error(
+            "----------------------BAD THING HAPPENED----------------------"
+        );
+        console.error("HTML5 Drag and Drop backend changed internally");
+        console.error("Drag and drop is probably broken");
+        console.error(
+            "----------------------BAD THING HAPPENED----------------------"
+        );
+    };
+
+    const untypesafeBackend: any = backend;
+
+    if (
+        untypesafeBackend.handleTopDragEnter === undefined ||
+        untypesafeBackend.handleTopDragEnter == null
+    ) {
+        welpThingsBroke();
+    }
+
+    untypesafeBackend.__original__handleTopDragEnter =
+        untypesafeBackend.handleTopDragEnter;
+
+    untypesafeBackend.handleTopDragEnter = (e: DragEvent) => {
+        untypesafeBackend.__original__handleTopDragEnter(e);
+        untypesafeBackend.altKeyPressed = e.ctrlKey || e.metaKey;
+    };
+
+    if (
+        untypesafeBackend.handleTopDragOver === undefined ||
+        untypesafeBackend.handleTopDragOver == null
+    ) {
+        welpThingsBroke();
+    }
+
+    untypesafeBackend.__original__handleTopDragOver =
+        untypesafeBackend.handleTopDragOver;
+    untypesafeBackend.handleTopDragOver = (e: DragEvent) => {
+        untypesafeBackend.__original__handleTopDragOver(e);
+        untypesafeBackend.altKeyPressed = e.ctrlKey || e.metaKey;
+    };
+
+    return backend;
+};
+
+const RNDContext = createDndContext(HTML5BackendWithCTRLKey);
 
 interface DragAndDropProps {
     children: React.ReactElement | null;

--- a/src/components/edit/DragAndDrop.tsx
+++ b/src/components/edit/DragAndDrop.tsx
@@ -24,7 +24,7 @@ export const HTML5BackendWithCTRLKey = (
 
     if (
         untypesafeBackend.handleTopDragEnter === undefined ||
-        untypesafeBackend.handleTopDragEnter == null
+        untypesafeBackend.handleTopDragEnter === null
     ) {
         welpThingsBroke();
     }
@@ -39,7 +39,7 @@ export const HTML5BackendWithCTRLKey = (
 
     if (
         untypesafeBackend.handleTopDragOver === undefined ||
-        untypesafeBackend.handleTopDragOver == null
+        untypesafeBackend.handleTopDragOver === null
     ) {
         welpThingsBroke();
     }

--- a/src/components/tutorial/DragAndDropChord.tsx
+++ b/src/components/tutorial/DragAndDropChord.tsx
@@ -46,6 +46,11 @@ const DragAndDropChord: React.FC<{}> = (): JSX.Element => {
             </Typography>
             <LineBreak />
             <Typography>
+                If you hold CTRL or CMD while dragging and dropping, the chord
+                will be copied instead of moved over.
+            </Typography>
+            <LineBreak />
+            <Typography>
                 Let's move the{" "}
                 <ChordTypography display="inline">B7</ChordTypography> above{" "}
                 <LyricsTypography display="inline">suddenly</LyricsTypography>{" "}


### PR DESCRIPTION
Adding CMD/CTRL chord drag and drop as a copy action, so that users can keep reusing chord symbols.

Huge hacks were done here because of React DND being both rigid (which can be good) and unmaintained (which makes things impossible along with the rigidity).

