### PR TITLE
Fixing Google Drive cache problem

### DIFF
--- a/src/components/track_player/FullSizedPlayer.tsx
+++ b/src/components/track_player/FullSizedPlayer.tsx
@@ -81,7 +81,7 @@ const FullSizedPlayer: React.FC<FullSizedPlayerProps> = (
     const paddingLeftStyle = usePaddingLeftStyle();
 
     const players = props.trackList.map((track: Track, index: number) => (
-        <Collapse in={index === props.currentTrackIndex} key={index}>
+        <Collapse in={index === props.currentTrackIndex} key={track.url}>
             <Box>
                 <ReactPlayer
                     url={track.url}

--- a/src/components/track_player/google_drive.ts
+++ b/src/components/track_player/google_drive.ts
@@ -1,0 +1,10 @@
+const googleDriveExportLinkRegex= new RegExp(`.*drive.google.com/.*?.+`)
+
+export const isGoogleDriveExportLink = (url: string): boolean => {
+    const results = url.match(googleDriveExportLinkRegex);
+    return results !== null;
+}
+
+export const addCacheBuster = (url: string, randID: string): string => {
+    return url + "&cacheBuster=" + randID;
+}


### PR DESCRIPTION
Problem: when using a Google Drive export link, Firefox (maybe also chrome, but who cares) will cache the series of redirects for the link, i.e.
hit export link -> 302
some intermediate links -> 302
some one time auth link -> 200

If the audio file is not completely loaded in the browser cache, Firefox will resume loading from the cached redirect, that is, the one time auth link, and end up at a 403.

This workaround adds a random cache buster (random ID parameter) so that the browser won't follow the cache and grab a new redirect link.