### PR TITLE
GDrive secret conversion key combo

### DIFF
--- a/src/components/track_player/google_drive.ts
+++ b/src/components/track_player/google_drive.ts
@@ -1,4 +1,5 @@
 const googleDriveExportLinkRegex= new RegExp(`.*drive.google.com/.*?.+`)
+const googleDriveViewerLinkRegex = new RegExp(`.*drive.google.com/file/d/(.+)/.*`)
 
 export const isGoogleDriveExportLink = (url: string): boolean => {
     const results = url.match(googleDriveExportLinkRegex);
@@ -7,4 +8,19 @@ export const isGoogleDriveExportLink = (url: string): boolean => {
 
 export const addCacheBuster = (url: string, randID: string): string => {
     return url + "&cacheBuster=" + randID;
+}
+
+export const convertViewLinkToExportLink = (url: string): string | null => {
+    const results = url.match(googleDriveViewerLinkRegex);
+    if (results === null) {
+        return null;
+    }
+
+    if (results.length < 2) {
+        return null;
+    }
+
+    const fileID = results[1];
+
+    return "https://drive.google.com/uc?export=download&id=" + fileID;
 }


### PR DESCRIPTION
Adding a key handler in the URL field of the track edit pane to convert a GDrive view link to a GDrive export link.
The secret key is CTRL/CMD + g