### PR TITLE
Implementing compact player

### DIFF
--- a/src/components/track_player/CompactPlayer.tsx
+++ b/src/components/track_player/CompactPlayer.tsx
@@ -1,0 +1,168 @@
+import {
+    Box,
+    Button as UnstyledButton,
+    Divider,
+    Slide,
+    Theme,
+    Typography,
+} from "@material-ui/core";
+import blueGrey from "@material-ui/core/colors/blueGrey";
+import ExpandIcon from "@material-ui/icons/Launch";
+import MinimizeIcon from "@material-ui/icons/Minimize";
+import UnstyledReplayIcon from "@material-ui/icons/Replay";
+import { ButtonProps } from "@material-ui/core/Button";
+
+import UnstyledPauseIcon from "@material-ui/icons/Pause";
+import UnstyledPlayIcon from "@material-ui/icons/PlayArrow";
+import { withStyles } from "@material-ui/styles";
+import React from "react";
+import { PlainFn } from "../../common/PlainFn";
+import {
+    roundedCornersStyle,
+    roundedTopCornersStyle,
+    TitleBar,
+    withBottomRightBox,
+} from "./common";
+
+interface CompactPlayerProps {
+    show: boolean;
+    playing: boolean;
+    onMaximize: PlainFn;
+    onMinimize: PlainFn;
+    currentTime: string;
+    onPlay: PlainFn;
+    onPause: PlainFn;
+}
+
+const PlayerBody = withStyles({
+    root: {
+        backgroundColor: blueGrey[50],
+        display: "flex",
+        justifyContent: "flex-end",
+        alignItems: "center",
+    },
+})(Box);
+
+const ButtonGroup = withStyles((theme: Theme) => ({
+    root: {
+        borderStyle: "solid",
+        borderColor: blueGrey[100],
+        borderLeftWidth: theme.spacing(0.25),
+        borderRightWidth: 0,
+        borderTopWidth: 0,
+        borderBottomWidth: 0,
+        paddingLeft: theme.spacing(1),
+        paddingRight: theme.spacing(1),
+        display: "flex",
+        alignContent: "center",
+    },
+}))(Box);
+
+const TimeDisplay = withStyles((theme: Theme) => ({
+    root: {
+        flex: 1,
+        display: "flex",
+        justifyContent: "center",
+        marginLeft: theme.spacing(1),
+        marginRight: theme.spacing(1),
+    },
+}))(Box);
+
+const JumpBackIcon = withStyles((theme: Theme) => ({
+    root: {
+        color: theme.palette.primary.main,
+    },
+}))(UnstyledReplayIcon);
+
+const PlayIcon = withStyles((theme: Theme) => ({
+    root: {
+        color: theme.palette.primary.main,
+    },
+}))(UnstyledPlayIcon);
+
+const PauseIcon = withStyles((theme: Theme) => ({
+    root: {
+        color: theme.palette.secondary.main,
+    },
+}))(UnstyledPauseIcon);
+
+const Button = withStyles((theme: Theme) => ({
+    root: {
+        minWidth: 0,
+        ...roundedCornersStyle(theme),
+    },
+}))(UnstyledButton);
+
+const PlayerContainer = withStyles((theme: Theme) => ({
+    root: {
+        backgroundColor: "white",
+        minWidth: "15vw",
+        ...roundedTopCornersStyle(theme),
+    },
+}))(Box);
+
+const CoolAssButton: React.FC<ButtonProps> = (props: ButtonProps) => {
+    return (
+        <Button {...props} size="small">
+            <Button size="small">{props.children}</Button>
+        </Button>
+    );
+};
+
+const CompactPlayer: React.FC<CompactPlayerProps> = (
+    props: CompactPlayerProps
+): JSX.Element => {
+    const titleBar = (
+        <TitleBar>
+            <Box />
+            <Box>
+                <Button onClick={props.onMinimize} size="small">
+                    <MinimizeIcon />
+                </Button>
+                <Button onClick={props.onMaximize} size="small">
+                    <ExpandIcon />
+                </Button>
+            </Box>
+        </TitleBar>
+    );
+
+    const playPauseButton = props.playing ? (
+        <CoolAssButton onClick={props.onPause}>
+            <PauseIcon />
+        </CoolAssButton>
+    ) : (
+        <CoolAssButton onClick={props.onPlay}>
+            <PlayIcon />
+        </CoolAssButton>
+    );
+
+    const controlPanel = (
+        <PlayerBody>
+            <TimeDisplay>
+                <Typography variant="h6">{props.currentTime}</Typography>
+            </TimeDisplay>
+
+            <ButtonGroup>
+                <CoolAssButton>
+                    <JumpBackIcon />
+                </CoolAssButton>
+
+                {playPauseButton}
+            </ButtonGroup>
+        </PlayerBody>
+    );
+
+    return (
+        <Slide in={props.show} direction="up">
+            {withBottomRightBox(
+                <PlayerContainer>
+                    {titleBar}
+                    <Divider />
+                    {controlPanel}
+                </PlayerContainer>
+            )}
+        </Slide>
+    );
+};
+
+export default CompactPlayer;

--- a/src/components/track_player/FullPlayer.tsx
+++ b/src/components/track_player/FullPlayer.tsx
@@ -16,27 +16,18 @@ import ReactPlayer from "react-player";
 import {
     roundedCornersStyle,
     roundedTopCornersStyle,
+    TitleBar,
     withBottomRightBox,
 } from "./common";
 import { TrackControl } from "./useMultiTrack";
 
-interface FullSizedPlayerProps {
+interface FullPlayerProps {
     show: boolean;
     trackControls: TrackControl[];
     onCollapse: () => void;
     onSelectCurrentTrack: (index: number) => void;
     onOpenTrackEditDialog?: () => void;
 }
-
-const TitleBar = withStyles((theme: Theme) => ({
-    root: {
-        width: "100%",
-        display: "flex",
-        justifyContent: "space-between",
-        alignItems: "center",
-        ...roundedTopCornersStyle(theme),
-    },
-}))(Box);
 
 const FlexBox = withStyles((theme: Theme) => ({
     root: {
@@ -74,8 +65,8 @@ const FullPlayerContainer = withStyles((theme: Theme) => ({
     },
 }))(Box);
 
-const FullSizedPlayer: React.FC<FullSizedPlayerProps> = (
-    props: FullSizedPlayerProps
+const FullPlayer: React.FC<FullPlayerProps> = (
+    props: FullPlayerProps
 ): JSX.Element => {
     const paddingLeftStyle = usePaddingLeftStyle();
 
@@ -101,6 +92,7 @@ const FullSizedPlayer: React.FC<FullSizedPlayerProps> = (
                             onPlay={trackControl.onPlay}
                             onPause={trackControl.onPause}
                             onProgress={handleProgress}
+                            progressInterval={500}
                             width="50vw"
                             height="auto"
                             config={{ file: { forceAudio: true } }}
@@ -187,4 +179,4 @@ const FullSizedPlayer: React.FC<FullSizedPlayerProps> = (
     );
 };
 
-export default FullSizedPlayer;
+export default FullPlayer;

--- a/src/components/track_player/MinimizedButton.tsx
+++ b/src/components/track_player/MinimizedButton.tsx
@@ -10,7 +10,7 @@ const ExpandButton = withStyles((theme: Theme) => ({
     },
 }))(Button);
 
-interface CollapsedButtonProps {
+interface MinimizedButtonProps {
     show: boolean;
     disabled?: boolean;
     tooltipMessage: string;
@@ -18,8 +18,8 @@ interface CollapsedButtonProps {
     className?: string;
 }
 
-const CollapsedButton: React.FC<CollapsedButtonProps> = (
-    props: CollapsedButtonProps
+const MinimizedButton: React.FC<MinimizedButtonProps> = (
+    props: MinimizedButtonProps
 ): JSX.Element => {
     return (
         <Slide in={props.show} direction="up">
@@ -42,4 +42,4 @@ const CollapsedButton: React.FC<CollapsedButtonProps> = (
     );
 };
 
-export default CollapsedButton;
+export default MinimizedButton;

--- a/src/components/track_player/TrackPlayer.tsx
+++ b/src/components/track_player/TrackPlayer.tsx
@@ -1,11 +1,12 @@
 import React, { useState } from "react";
 import { Track } from "../../common/ChordModel/Track";
-import CollapsedButton from "./CollapsedButton";
-import FullSizedPlayer from "./FullSizedPlayer";
+import MinimizedButton from "./MinimizedButton";
+import CompactPlayer from "./CompactPlayer";
+import FullPlayer from "./FullPlayer";
 import TrackListEditDialog from "./TrackListEditDialog";
 import { useMultiTrack } from "./useMultiTrack";
 
-type PlayerVisibilityState = "collapsed" | "full";
+type PlayerVisibilityState = "minimized" | "compact" | "full";
 
 interface TrackPlayerProps {
     trackList: Track[];
@@ -18,26 +19,26 @@ const TrackPlayer: React.FC<TrackPlayerProps> = (
 ): JSX.Element => {
     const [playerVisibilityState, setPlayerVisibilityState] = useState<
         PlayerVisibilityState
-    >("collapsed");
+    >("minimized");
 
     const [trackEditDialogOpen, setTrackEditDialogOpen] = useState(false);
     const [loadPlayers, setLoadPlayers] = useState(false);
 
-    const [trackControls, onCurrentTrackIndexChange] = useMultiTrack(
+    const [fullPlayerControl, compactPlayerControl] = useMultiTrack(
         props.trackList
     );
 
     const canEditTrackList = props.onTrackListChanged !== undefined;
-    const trackListIsEmpty = trackControls.length === 0;
+    const trackListIsEmpty = fullPlayerControl.trackControls.length === 0;
 
     const collapsedButtonFn = (
         disabled: boolean,
         expandFn: () => void,
         tooltipMessage: string
     ) => (
-        <CollapsedButton
+        <MinimizedButton
             className={props.collapsedButtonClassName}
-            show={playerVisibilityState === "collapsed"}
+            show={playerVisibilityState === "minimized"}
             tooltipMessage={tooltipMessage}
             disabled={disabled}
             onClick={expandFn}
@@ -82,11 +83,11 @@ const TrackPlayer: React.FC<TrackPlayerProps> = (
     }
 
     const fullPlayer: false | JSX.Element = loadPlayers && (
-        <FullSizedPlayer
+        <FullPlayer
             show={playerVisibilityState === "full"}
-            trackControls={trackControls}
-            onCollapse={() => setPlayerVisibilityState("collapsed")}
-            onSelectCurrentTrack={onCurrentTrackIndexChange}
+            trackControls={fullPlayerControl.trackControls}
+            onCollapse={() => setPlayerVisibilityState("compact")}
+            onSelectCurrentTrack={fullPlayerControl.onCurrentTrackIndexChange}
             onOpenTrackEditDialog={
                 canEditTrackList
                     ? () => setTrackEditDialogOpen(true)
@@ -95,12 +96,24 @@ const TrackPlayer: React.FC<TrackPlayerProps> = (
         />
     );
 
+    const compactPlayer: false | JSX.Element = loadPlayers && (
+        <CompactPlayer
+            show={playerVisibilityState === "compact"}
+            playing={compactPlayerControl.playing}
+            onPlay={compactPlayerControl.onPlay}
+            onPause={compactPlayerControl.onPause}
+            onMinimize={() => setPlayerVisibilityState("minimized")}
+            onMaximize={() => setPlayerVisibilityState("full")}
+            currentTime={compactPlayerControl.currentTime}
+        />
+    );
+
     const collapsedButtonClickHandler = () => {
         if (!loadPlayers) {
             setLoadPlayers(true);
         }
 
-        setPlayerVisibilityState("full");
+        setPlayerVisibilityState("compact");
     };
 
     return (
@@ -110,6 +123,7 @@ const TrackPlayer: React.FC<TrackPlayerProps> = (
                 collapsedButtonClickHandler,
                 "Show Player"
             )}
+            {compactPlayer}
             {fullPlayer}
             {trackEditDialog}
         </>

--- a/src/components/track_player/common.tsx
+++ b/src/components/track_player/common.tsx
@@ -23,3 +23,26 @@ const BottomRightBox = withStyles((theme: Theme) => ({
 export const withBottomRightBox = (children: React.ReactElement) => (
     <BottomRightBox boxShadow={4}>{children}</BottomRightBox>
 );
+
+const BottomLeftBox = withStyles((theme: Theme) => ({
+    root: {
+        position: "fixed",
+        bottom: 0,
+        left: theme.spacing(2),
+        ...roundedTopCornersStyle(theme),
+    },
+}))(Box);
+
+export const withBottomLeftBox = (children: React.ReactElement) => (
+    <BottomLeftBox boxShadow={4}>{children}</BottomLeftBox>
+);
+
+export const TitleBar = withStyles((theme: Theme) => ({
+    root: {
+        width: "100%",
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        ...roundedTopCornersStyle(theme),
+    },
+}))(Box);


### PR DESCRIPTION
Adding the small sized compact player - this is the intended size that I expect most users to interact with since it is small and out of the way.

<img width="389" alt="image" src="https://user-images.githubusercontent.com/5819893/110231149-b334af00-7eca-11eb-9353-17479587272a.png">

one issue: the time display is lagging on the order of 1 second or so
