### PR TITLE
Bug: Player out of sync

### DIFF
--- a/src/components/track_player/ControlButton.tsx
+++ b/src/components/track_player/ControlButton.tsx
@@ -32,39 +32,61 @@ const SecondaryButton = withStyles((theme: Theme) => ({
 
 const makeControlButton = (
     child: React.ReactElement,
+    key: string,
     tooltipMsg: string,
     color: "primary" | "secondary"
 ): React.FC<ButtonProps> => {
     const ColoredButton = color === "primary" ? PrimaryButton : SecondaryButton;
 
     return (props: ButtonProps) => (
-        <Tooltip title={tooltipMsg}>
-            <ColoredButton {...props} size="small">
-                <ColoredButton disabled={props.disabled} size="small">
-                    {child}
-                </ColoredButton>
+        <Tooltip key={key} title={tooltipMsg}>
+            <ColoredButton {...props} size="large">
+                {child}
             </ColoredButton>
         </Tooltip>
     );
 };
 
 export const ControlButton = {
-    Play: makeControlButton(<PlayIcon />, "Play the damn song", "primary"),
-    Pause: makeControlButton(<PauseIcon />, "Pause", "secondary"),
-    JumpBack: makeControlButton(<JumpBackIcon />, "Jump Back", "primary"),
+    Play: makeControlButton(
+        <PlayIcon />,
+        "play-button",
+        "Play the damn song",
+        "primary"
+    ),
+    Pause: makeControlButton(
+        <PauseIcon />,
+        "pause-button",
+        "Pause",
+        "secondary"
+    ),
+    JumpBack: makeControlButton(
+        <JumpBackIcon />,
+        "jump-back-buttonn",
+        "Jump Back",
+        "primary"
+    ),
     JumpForward: makeControlButton(
         <JumpForwardIcon />,
+        "jump-forward-button",
         "Jump Forward",
         "primary"
     ),
-    SkipBack: makeControlButton(<SkipBackIcon />, "Go to Beginning", "primary"),
+    SkipBack: makeControlButton(
+        <SkipBackIcon />,
+        "skip-back-button",
+        "Go to Beginning",
+        "primary"
+    ),
     DecreasePlayrate: makeControlButton(
         <DecreasePlayrateIcon />,
+        "decrease-playrate-button",
         "Play slower",
         "primary"
     ),
     IncreasePlayrate: makeControlButton(
         <IncreasePlayrateIcon />,
+        "increase-playrate-button",
         "Play faster",
         "primary"
     ),

--- a/src/components/track_player/ControlGroup.tsx
+++ b/src/components/track_player/ControlGroup.tsx
@@ -26,12 +26,16 @@ const ControlGroup: React.FC<ControlGroupProps> = (
     props: ControlGroupProps
 ): JSX.Element => {
     const contents: React.ReactElement[] = props.children.map(
-        (child: React.ReactElement) => {
+        (child: React.ReactElement, index: number) => {
             return (
-                <>
+                <React.Fragment key={index}>
                     {child}
-                    <VerticalMiddleDivider orientation="vertical" flexItem />
-                </>
+                    <VerticalMiddleDivider
+                        key={`divider-${index}`}
+                        orientation="vertical"
+                        flexItem
+                    />
+                </React.Fragment>
             );
         }
     );

--- a/src/components/track_player/FullPlayer.tsx
+++ b/src/components/track_player/FullPlayer.tsx
@@ -122,8 +122,8 @@ const FullPlayer: React.FC<FullPlayerProps> = (
                         playing={trackControl.playing}
                         controls
                         playbackRate={playbackRate}
-                        onPlay={trackControl.play}
-                        onPause={trackControl.pause}
+                        onPlay={trackControl.onPlay}
+                        onPause={trackControl.onPause}
                         onProgress={handleProgress}
                         progressInterval={500}
                         width="50vw"


### PR DESCRIPTION
Problem: on rapid button clicks on the player, e.g. play then pause, or jump back then pause, etc, React Player runs into some sort of race condition where its behaviour becomes decoupled from its input props (specificially `playing`). This is an (unpleasant) workaround to fix it.