### PR TITLE
change redirect into a route

### DIFF
--- a/src/components/SongRouter.tsx
+++ b/src/components/SongRouter.tsx
@@ -29,12 +29,9 @@ const SongRouter: MultiFC<SongRouterProps> = (
     };
 
     return [
-        <Redirect
-            key={props.path.URL()}
-            from={props.path.URL()}
-            to={editPath.URL()}
-            exact
-        />,
+        <Route key={props.path.URL()} path={props.path.URL()} exact>
+            <Redirect to={editPath.URL()} />,
+        </Route>,
         <Route key={editPath.URL()} path={editPath.URL()}>
             <ChordPaper
                 song={props.song}


### PR DESCRIPTION
Bug: refreshing a play view will redirect into the edit view

I don't fully comprehend, but seems like react router's <Redirect>'s from parameter doesn't actually do anything - it will just execute a redirect upon mounting. Wrapping this in a route seems to solve the problem.

before: /song/id/play -> <song fetching> -> <rendering react routes + redirect> -> <redirect to /song/id/edit>

now: /song/id/play -> <song fetching> -> <rendering react routes + redirect> -> does not redirect because the redirect is wrapped inside another route