### PR TITLE
More compact player buttons

### DIFF
--- a/src/components/track_player/CompactPlayer.tsx
+++ b/src/components/track_player/CompactPlayer.tsx
@@ -33,7 +33,9 @@ interface CompactPlayerProps {
     play: PlainFn;
     pause: PlainFn;
     jumpBack: PlainFn;
+    jumpForward: PlainFn;
     skipBack: ButtonActionAndState;
+    skipForward: ButtonActionAndState;
 }
 
 const TimeDisplay = withStyles((theme: Theme) => ({
@@ -95,6 +97,11 @@ const CompactPlayer: React.FC<CompactPlayerProps> = (
                 />
                 <ControlButton.JumpBack onClick={props.jumpBack} />
                 {playPauseButton}
+                <ControlButton.JumpForward onClick={props.jumpForward} />
+                <ControlButton.SkipForward
+                    disabled={!props.skipForward.enabled}
+                    onClick={props.skipForward.action}
+                />
             </ControlGroup>
             <TimeDisplay>
                 <Box>

--- a/src/components/track_player/TrackPlayer.tsx
+++ b/src/components/track_player/TrackPlayer.tsx
@@ -108,7 +108,9 @@ const TrackPlayer: React.FC<TrackPlayerProps> = (
             play={compactPlayerControl.play}
             pause={compactPlayerControl.pause}
             jumpBack={compactPlayerControl.jumpBack}
+            jumpForward={compactPlayerControl.jumpForward}
             skipBack={compactPlayerControl.skipBack}
+            skipForward={compactPlayerControl.skipForward}
             onMinimize={() => setPlayerVisibilityState("minimized")}
             onMaximize={() => setPlayerVisibilityState("full")}
             currentTime={compactPlayerControl.currentTime}

--- a/src/components/track_player/useMultiTrack.ts
+++ b/src/components/track_player/useMultiTrack.ts
@@ -39,7 +39,9 @@ interface CompactPlayerControl {
     play: PlainFn;
     pause: PlainFn;
     jumpBack: PlainFn;
+    jumpForward: PlainFn;
     skipBack: ButtonActionAndState;
+    skipForward: ButtonActionAndState;
     currentTime: string;
 }
 
@@ -315,7 +317,9 @@ export const useMultiTrack = (
         play: playAction,
         pause: pauseAction,
         skipBack: skipBackButton,
+        skipForward: skipForwardButton,
         jumpBack: jumpBackAction,
+        jumpForward: jumpForwardAction,
         currentTime: currentTimeFormatted,
     };
 


### PR DESCRIPTION
Adding the forward buttons to the compact player.

I thought about keeping it more spartan, but the forward buttons aren't superfluous - they're important for helping navigate a song esp if the user goes too far back and doesn't want to wait 30 seconds to get back to where they were. I think having these buttons in this view will justify this view more.