### PR TITLE
Add Play Button in Full Track Player

### DIFF
--- a/src/components/track_player/FullPlayer.tsx
+++ b/src/components/track_player/FullPlayer.tsx
@@ -86,6 +86,12 @@ const FullPlayer: React.FC<FullPlayerProps> = (
     const paddingLeftStyle = usePaddingLeftStyle();
 
     const makeControlPane = (trackControl: TrackControl) => {
+        const playPauseButton = trackControl.playing ? (
+            <ControlButton.Pause onClick={trackControl.pause} />
+        ) : (
+            <ControlButton.Play onClick={trackControl.play} />
+        );
+
         return (
             <ControlPane>
                 <ControlGroup>
@@ -97,6 +103,7 @@ const FullPlayer: React.FC<FullPlayerProps> = (
                         onClick={trackControl.skipBack.action}
                     />
                     <ControlButton.JumpBack onClick={trackControl.jumpBack} />
+                    {playPauseButton}
                     <ControlButton.JumpForward
                         onClick={trackControl.jumpForward}
                     />
@@ -133,7 +140,7 @@ const FullPlayer: React.FC<FullPlayerProps> = (
                         ref={trackControl.ref}
                         url={trackControl.url}
                         playing={trackControl.playing}
-                        controls
+                        controls={false}
                         playbackRate={playbackRate}
                         onPlay={trackControl.onPlay}
                         onPause={trackControl.onPause}

--- a/src/components/track_player/useMultiTrack.ts
+++ b/src/components/track_player/useMultiTrack.ts
@@ -24,13 +24,15 @@ export interface ButtonActionAndState {
 export interface TrackControl extends Track {
     focused: boolean;
     playing: boolean;
-    onPlay: PlainFn;
-    onPause: PlainFn;
+    play: PlainFn;
+    pause: PlainFn;
     jumpBack: PlainFn;
     jumpForward: PlainFn;
     goToBeginning: PlainFn;
     skipBack: ButtonActionAndState;
     skipForward: ButtonActionAndState;
+    onPlay: PlainFn;
+    onPause: PlainFn;
     onProgress: (playedSeconds: number) => void;
     ref: React.Ref<ReactPlayer>;
 }
@@ -270,7 +272,7 @@ export const useMultiTrack = (
     };
 
     const trackControls: TrackControl[] = trackList.map(
-        (track: Track, index: number) => {
+        (track: Track, index: number): TrackControl => {
             const focused = index === currentTrackIndex;
 
             const thisIfFocused = <T>(thisThing: T, elseThing: T) => {
@@ -289,13 +291,15 @@ export const useMultiTrack = (
                 url: processTrackURL(track.url),
                 focused: focused,
                 playing: focused && playing,
-                onPlay: fnIfFocused(handlePlayState),
-                onPause: fnIfFocused(handlePauseState),
+                play: fnIfFocused(playAction),
+                pause: fnIfFocused(pauseAction),
                 goToBeginning: fnIfFocused(goToBeginningAction),
                 jumpBack: fnIfFocused(jumpBackAction),
                 jumpForward: fnIfFocused(jumpForwardAction),
                 skipBack: thisIfFocused(skipBackButton, emptyButton),
                 skipForward: thisIfFocused(skipForwardButton, emptyButton),
+                onPlay: fnIfFocused(handlePlayState),
+                onPause: fnIfFocused(handlePauseState),
                 onProgress: thisIfFocused(handleProgress, voidFn),
                 ref: playerRefs.current[index],
             };


### PR DESCRIPTION
Also adding the play/pause button in the full view, even though it's also provided by the embedded player. It's a bit jarring to go to 2 different places to navigate, although it does create some nonstreamlined experience by having 2 ways to play/pause.

Will provide an options dialog to disable embedded controls in the future.