### PR TITLE
Bug: Fix Play Line rendering

### DIFF
--- a/src/components/play/PlayLine.tsx
+++ b/src/components/play/PlayLine.tsx
@@ -42,7 +42,7 @@ const PlayLine: React.FC<PlayLineProps> = (
         );
 
         lineComponent = (
-            <Box display="inline-block">
+            <Box>
                 {labelElement}
                 {lineComponent}
             </Box>


### PR DESCRIPTION
Bug: the inline-block style causes chord lines to be placed on the same line if they're short enough. I can't remember why this was ever here in the first place - removing.