### PR TITLE
Bug: Fix Chord Input size

### DIFF
--- a/src/components/edit/TextInput.tsx
+++ b/src/components/edit/TextInput.tsx
@@ -18,6 +18,7 @@ const TextInput: React.FC<TextInputProps> = (
 
     return (
         <ControlledTextInput
+            classes={props.classes}
             value={value}
             onValueChange={setValue}
             variant={props.variant}


### PR DESCRIPTION
In refactoring, props.classes had been neglected to be propagated down, this caused chord inputs to be super long as opposed to the specified width.