### PR TITLE
Prevent other users from trying to save the tracklist

### DIFF
--- a/src/components/edit/ChordPaper.tsx
+++ b/src/components/edit/ChordPaper.tsx
@@ -50,7 +50,7 @@ const ChordPaper: React.FC<ChordPaperProps> = (
         }
 
         return (
-            <TrackListProvider songID={props.song.id}>
+            <TrackListProvider song={props.song}>
                 {(
                     tracklist: TrackList,
                     changeHandler: TrackListChangeHandler

--- a/src/components/play/Play.tsx
+++ b/src/components/play/Play.tsx
@@ -47,7 +47,7 @@ const Play: React.FC<PlayProps> = (props: PlayProps): JSX.Element => {
         }
 
         return (
-            <TrackListProvider songID={props.song.id}>
+            <TrackListProvider song={props.song}>
                 {(tracklist: TrackList) => (
                     <TrackPlayer
                         collapsedButtonClassName={transparentStyle.root}

--- a/src/components/track_player/TrackListProvider.tsx
+++ b/src/components/track_player/TrackListProvider.tsx
@@ -3,6 +3,7 @@ import { isLeft } from "fp-ts/lib/These";
 import React, { useState } from "react";
 import { useErrorMessage } from "../../common/backend/errors";
 import { getTrackList, updateTrackList } from "../../common/backend/requests";
+import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { TrackList } from "../../common/ChordModel/Track";
 import { FetchState } from "../../common/fetch";
 import ErrorImage from "../display/ErrorImage";
@@ -12,7 +13,7 @@ import MinimizedButton from "./MinimizedButton";
 export type TrackListChangeHandler = (tracklist: TrackList) => void;
 
 interface TrackListProviderProps {
-    songID: string;
+    song: ChordSong;
     children: (
         tracklist: TrackList,
         changeHandler: TrackListChangeHandler
@@ -48,12 +49,12 @@ const TrackListProvider: React.FC<TrackListProviderProps> = (
     };
 
     const fetchTrackList = async () => {
-        let fetchResult = await getTrackList(props.songID);
+        let fetchResult = await getTrackList(props.song.id);
         handleFetchedTracklist(fetchResult);
     };
 
     const handleTrackListChanged = async (tracklist: TrackList) => {
-        if (user === null) {
+        if (user === null || !props.song.isOwner(user)) {
             setFetchState({ state: "loaded", item: tracklist });
             return;
         }


### PR DESCRIPTION
Don't try to save the tracklist if the change is initiated by a non-owner. The backend should prevent this already, but it will cause an unpleasant user experience to get a ton of error messages. When a non-owner tries to change, just change the tracklist locally but do not persist to the cloud.