### PR TITLE
Play view: reduce scroll button set

### DIFF
--- a/src/components/play/PlayContent.tsx
+++ b/src/components/play/PlayContent.tsx
@@ -5,6 +5,7 @@ import { useWindowWidth } from "@react-hook/window-size";
 import React, { useEffect, useState } from "react";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
+import { isScrollBackwardsKey, isScrollForwardsKey } from "./keyMap";
 import PlayLine from "./PlayLine";
 
 export interface DisplaySettings {
@@ -171,18 +172,17 @@ const PlayContent: React.FC<PlayContentProps> = (
 
     useEffect(() => {
         const handleKey = (event: KeyboardEvent) => {
-            // only three keys ever go backwards, everything else goes forwards
-            if (
-                event.key === "ArrowLeft" ||
-                event.key === "ArrowUp" ||
-                event.key === "Backspace"
-            ) {
+            if (isScrollBackwardsKey(event.code)) {
                 scrollBackward();
-            } else {
-                scrollForward();
+                event.preventDefault();
+                return;
             }
 
-            event.preventDefault();
+            if (isScrollForwardsKey(event.code)) {
+                scrollForward();
+                event.preventDefault();
+                return;
+            }
         };
 
         window.addEventListener("keydown", handleKey);

--- a/src/components/play/keyMap.ts
+++ b/src/components/play/keyMap.ts
@@ -1,0 +1,81 @@
+const scrollBackwardsKeys: string[] = [
+    "ArrowUp",
+    "ArrowLeft",
+    "Backspace",
+    "ShiftLeft",
+];
+
+export const isScrollBackwardsKey = (code: string): boolean => {
+    for (let backwardsKey in scrollBackwardsKeys) {
+        if (backwardsKey === code) {
+            return true;
+        }
+    }
+
+    return false;
+};
+
+export const scrollForwardKeys: string[] = [
+    "KeyA",
+    "KeyB",
+    "KeyC",
+    "KeyD",
+    "KeyE",
+    "KeyF",
+    "KeyG",
+    "KeyH",
+    "KeyI",
+    "KeyJ",
+    "KeyK",
+    "KeyL",
+    "KeyM",
+    "KeyN",
+    "KeyO",
+    "KeyP",
+    "KeyQ",
+    "KeyR",
+    "KeyS",
+    "KeyT",
+    "KeyU",
+    "KeyV",
+    "KeyW",
+    "KeyX",
+    "KeyY",
+    "KeyZ",
+    "Digit1",
+    "Digit2",
+    "Digit3",
+    "Digit4",
+    "Digit5",
+    "Digit6",
+    "Digit7",
+    "Digit8",
+    "Digit9",
+    "Digit0",
+    "Space",
+    "Enter",
+    "ArrowDown",
+    "ArrowRight",
+    "Comma",
+    "Period",
+    "Slash",
+    "Backslash",
+    "Semicolon",
+    "Quote",
+    "Backquote",
+    "Tab",
+    "ShiftRight",
+    "Equal",
+    "BracketLeft",
+    "BracketRight",
+];
+
+export const isScrollForwardsKey = (code: string): boolean => {
+    for (let forwardsKey in scrollForwardKeys) {
+        if (forwardsKey === code) {
+            return true;
+        }
+    }
+
+    return false;
+};


### PR DESCRIPTION
"Everything else scrolls forward" as a behaviour is too aggressive - this creates situations where even pressing the volume up button or CTRL + T for a new tab would cause scrolling.

Narrowing it down to the "general" set of keyboard buttons - had to specify each individually though which was not fun.