### PR TITLE
Fix: mute when volume goes to 0

### DIFF
--- a/src/components/track_player/internal_player/4stems/LoadedFourStemTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/4stems/LoadedFourStemTrackPlayer.tsx
@@ -178,12 +178,16 @@ const LoadedFourStemTrackPlayer: React.FC<LoadedFourStemTrackPlayerProps> = (
             const stemVolumeFraction =
                 (playerState.stems[stemKey].volume / 100) *
                 (playerState.masterVolume / 100);
-            const stemVolumeDecibels = 20 * Math.log10(stemVolumeFraction);
 
-            toneNodes[stemKey].volumeNode.volume.value = stemVolumeDecibels;
+            // don't set if fraction is 0, log of 0 is undefined
+            if (stemVolumeFraction > 0) {
+                const stemVolumeDecibels = 20 * Math.log10(stemVolumeFraction);
+                toneNodes[stemKey].volumeNode.volume.value = stemVolumeDecibels;
+            }
 
             // mute needs to be set last because it can be overrided by volume
-            toneNodes[stemKey].endNode.mute = playerState.stems[stemKey].muted;
+            toneNodes[stemKey].endNode.mute =
+                playerState.stems[stemKey].muted || stemVolumeFraction === 0;
         }
     }, [toneNodes, playerState]);
 


### PR DESCRIPTION
Special handling for when volume is 0 - seems like setting it to negative infinity manually doesn't turn the track off, so toggling the mute when volume reaches zero.