### PR TITLE
Adjusting play speed for multi stem player

### DIFF
--- a/src/components/track_player/JamStation.tsx
+++ b/src/components/track_player/JamStation.tsx
@@ -34,8 +34,6 @@ const JamStation: React.FC<JamStationProps> = (
     const [loadPlayers, setLoadPlayers] = useState(false);
 
     const [currentTrackIndex, setCurrentTrackIndex] = useState(0);
-    const [playrate, setPlayrate] = useState(100);
-
     const [addTopKeyListener, removeKeyListener] = useRegisterTopKeyListener();
 
     const canEditTrackList = props.onTrackListChanged !== undefined;
@@ -150,8 +148,6 @@ const JamStation: React.FC<JamStationProps> = (
             show={playerVisibilityState === "full"}
             tracklist={props.trackList}
             timeSections={props.timeSections}
-            playrate={playrate}
-            onPlayrateChange={setPlayrate}
             currentTrackIndex={currentTrackIndex}
             onSelectCurrentTrack={setCurrentTrackIndex}
             onMinimize={minimizePlayer}

--- a/src/components/track_player/MultiTrackPlayer.tsx
+++ b/src/components/track_player/MultiTrackPlayer.tsx
@@ -67,9 +67,6 @@ interface MultiTrackPlayerProps {
     currentTrackIndex: number;
     onSelectCurrentTrack: (index: number) => void;
 
-    playrate: number;
-    onPlayrateChange: (newPlayrate: number) => void;
-
     onOpenTrackEditDialog?: PlainFn;
     onMinimize: PlainFn;
 }
@@ -143,8 +140,6 @@ const MultiTrackPlayer: React.FC<MultiTrackPlayerProps> = (
                     currentTrack={currentTrack}
                     track={track}
                     timeSections={props.timeSections}
-                    playrate={props.playrate}
-                    onPlayrateChange={props.onPlayrateChange}
                 />
             );
         }

--- a/src/components/track_player/TrackPlayer.tsx
+++ b/src/components/track_player/TrackPlayer.tsx
@@ -11,9 +11,6 @@ interface TrackPlayerProps {
 
     track: Track;
     readonly timeSections: TimeSection[];
-
-    playrate: number;
-    onPlayrateChange: (newPlayrate: number) => void;
 }
 
 const TrackPlayer: React.FC<TrackPlayerProps> = (
@@ -28,8 +25,6 @@ const TrackPlayer: React.FC<TrackPlayerProps> = (
                         currentTrack={props.currentTrack}
                         track={props.track}
                         timeSections={props.timeSections}
-                        playrate={props.playrate}
-                        onPlayrateChange={props.onPlayrateChange}
                     />
                 );
             }
@@ -41,8 +36,6 @@ const TrackPlayer: React.FC<TrackPlayerProps> = (
                         currentTrack={props.currentTrack}
                         track={props.track}
                         timeSections={props.timeSections}
-                        playrate={props.playrate}
-                        onPlayrateChange={props.onPlayrateChange}
                     />
                 );
             }

--- a/src/components/track_player/internal_player/4stems/FourStemTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/4stems/FourStemTrackPlayer.tsx
@@ -36,9 +36,6 @@ interface FourStemTrackPlayerProps {
 
     track: FourStemsTrack;
     readonly timeSections: TimeSection[];
-
-    playrate: number;
-    onPlayrateChange: (newPlayrate: number) => void;
 }
 
 interface SingleLoadingProgress {
@@ -259,8 +256,6 @@ const FourStemTrackPlayer: React.FC<FourStemTrackPlayerProps> = (
             currentTrack={props.currentTrack}
             audioBuffers={fetchState.item}
             timeSections={props.timeSections}
-            playrate={props.playrate}
-            onPlayrateChange={props.onPlayrateChange}
         />
     );
 };

--- a/src/components/track_player/internal_player/ControlPane.tsx
+++ b/src/components/track_player/internal_player/ControlPane.tsx
@@ -20,8 +20,8 @@ interface ControlPaneProps {
     onGoToBeginning: PlainFn;
     onSkipBack: ButtonActionAndState;
     onSkipForward: ButtonActionAndState;
-    playrate: number;
-    onPlayrateChange: (newPlayrate: number) => void;
+    playratePercentage: number;
+    onPlayratePercentageChange: (newPlayrate: number) => void;
     sectionLabel: string;
 }
 
@@ -119,8 +119,8 @@ const ControlPane: React.FC<ControlPaneProps> = (
             </ControlGroup>
             <SectionLabel value={props.sectionLabel} />
             <PlayrateControl
-                playrate={props.playrate}
-                onChange={props.onPlayrateChange}
+                playratePercentage={props.playratePercentage}
+                onChange={props.onPlayratePercentageChange}
             />
         </ControlPaneBox>
     );

--- a/src/components/track_player/internal_player/PlayrateControl.tsx
+++ b/src/components/track_player/internal_player/PlayrateControl.tsx
@@ -23,22 +23,22 @@ const PercentageDisplay = withStyles((theme: Theme) => {
 })(Typography);
 
 interface PlayrateControlProps {
-    playrate: number;
-    onChange: (newPlayrate: number) => void;
+    playratePercentage: number;
+    onChange: (newPlayratePercentage: number) => void;
 }
 
 const PlayrateControl: React.FC<PlayrateControlProps> = (
     props: PlayrateControlProps
 ): JSX.Element => {
-    const playrate = Math.round(props.playrate);
-    const interval = 10;
+    const playrate = Math.round(props.playratePercentage);
+    const interval = 5;
     const percentage: string = `${playrate}%`;
 
     const onDecrease = () => props.onChange(playrate - interval);
     const onIncrease = () => props.onChange(playrate + interval);
 
-    const decreaseDisabled = playrate - interval <= 0;
-    const increaseDisabled = playrate + interval > 200;
+    const decreaseDisabled = playrate - interval < 50;
+    const increaseDisabled = playrate + interval > 150;
 
     return (
         <PlayrateBox>

--- a/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
@@ -1,5 +1,5 @@
 import { Box } from "@material-ui/core";
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import ReactPlayer, { ReactPlayerProps } from "react-player";
 import shortid from "shortid";
 import { TimeSection } from "../../../../common/ChordModel/ChordLine";
@@ -15,15 +15,13 @@ interface SingleTrackPlayerProps {
 
     track: SingleTrack;
     readonly timeSections: TimeSection[];
-
-    playrate: number;
-    onPlayrateChange: (newPlayrate: number) => void;
 }
 
 const SingleTrackPlayer: React.FC<SingleTrackPlayerProps> = (
     props: SingleTrackPlayerProps
 ): JSX.Element => {
     const playerRef = useRef<ReactPlayer>();
+    const [playratePercentage, setPlayratePercentage] = useState(100);
     const timeControl = useTimeControls(playerRef.current);
     const trackURL: string = useMemo(
         () => ensureGoogleDriveCacheBusted(props.track.url, shortid.generate()),
@@ -41,7 +39,7 @@ const SingleTrackPlayer: React.FC<SingleTrackPlayerProps> = (
         ref: playerRef,
         playing: timeControl.playing,
         controls: true,
-        playbackRate: props.playrate / 100,
+        playbackRate: playratePercentage / 100,
         onPlay: timeControl.onPlay,
         onPause: timeControl.onPause,
         onProgress: timeControl.onProgress,
@@ -76,8 +74,8 @@ const SingleTrackPlayer: React.FC<SingleTrackPlayerProps> = (
                 onSkipBack={skipBack}
                 onSkipForward={skipForward}
                 onGoToBeginning={timeControl.goToBeginning}
-                playrate={props.playrate}
-                onPlayrateChange={props.onPlayrateChange}
+                playratePercentage={playratePercentage}
+                onPlayratePercentageChange={setPlayratePercentage}
             />
         </Box>
     );


### PR DESCRIPTION
Implemented adjustment of playback speed for the multi stem player. Also pushed the playrate state down to the individual player level - if playback time is not shared, then no real reason for playback speed to be shared.