### PR TITLE
Improve play speed change sound quality

### DIFF
--- a/src/components/track_player/internal_player/PlayrateControl.tsx
+++ b/src/components/track_player/internal_player/PlayrateControl.tsx
@@ -38,7 +38,7 @@ const PlayrateControl: React.FC<PlayrateControlProps> = (
     const onIncrease = () => props.onChange(playrate + interval);
 
     const decreaseDisabled = playrate - interval < 50;
-    const increaseDisabled = playrate + interval > 150;
+    const increaseDisabled = playrate + interval > 100;
 
     return (
         <PlayrateBox>


### PR DESCRIPTION
The grain player kind of sucks and causes a lot of jittery artifacts, going with the original approach of changing the speed, then running through a pitch shift to compensate for the change in frequency. This seems to give a more stable result.