### PR TITLE
Prompt user from navigating away if there are unsaved changes

### DIFF
--- a/src/common/paths.ts
+++ b/src/common/paths.ts
@@ -76,6 +76,11 @@ export class SongIDModePath {
         const result = path.match(/\/song\/.+\/play/i);
         return result !== null;
     }
+
+    static isEditMode(path: string): boolean {
+        const result = path.match(/\/song\/.+\/edit/i);
+        return result !== null;
+    }
 }
 
 export class DemoPath {


### PR DESCRIPTION
Adding event handlers on navigation or window closing events if the user tries to navigate away while the song is unsaved - so that there's no surprise if they lose their changes.