### PR TITLE
Fix: playview intercept only default body keystrokes

### DIFF
--- a/src/components/play/PlayContent.tsx
+++ b/src/components/play/PlayContent.tsx
@@ -177,6 +177,12 @@ const PlayContent: React.FC<PlayContentProps> = (
 
     useEffect(() => {
         const handleKey = (event: KeyboardEvent) => {
+            // only fire for "default" targets, when the user isn't particularly interacting
+            // with anything else
+            if (event.target !== document.body) {
+                return;
+            }
+
             if (isScrollBackwardsKey(event.code)) {
                 scrollBackward();
                 event.preventDefault();


### PR DESCRIPTION
Allow playcontent to only intercept the keystrokes that are aimed at the default "body" so that it doesn't steal keystrokes from other things, e.g. text fields.