### PR TITLE
Play mode: scroll by column option

### DIFF
--- a/src/components/play/DisplaySettingsDialog.tsx
+++ b/src/components/play/DisplaySettingsDialog.tsx
@@ -47,10 +47,10 @@ interface DialogInput {
     numberOfColumns: string;
     fontSize: string;
     columnMargin: string;
-    scrollWidth: DisplaySettings["scrollWidth"];
+    scrollType: DisplaySettings["scrollType"];
 }
 
-type TextInputFieldKeys = keyof Omit<DialogInput, "scrollWidth">;
+type TextInputFieldKeys = keyof Omit<DialogInput, "scrollType">;
 
 interface InputFieldSpecification {
     label: string;
@@ -73,7 +73,7 @@ const DisplaySettingsDialog: React.FC<DisplaySettingsDialogProps> = (
         numberOfColumns: props.defaultSettings.numberOfColumnsPerPage.toString(),
         fontSize: props.defaultSettings.fontSize.toString(),
         columnMargin: props.defaultSettings.columnMargin.toString(),
-        scrollWidth: props.defaultSettings.scrollWidth,
+        scrollType: props.defaultSettings.scrollType,
     });
 
     const validateNumber = (strValue: string): Either<Error, number> => {
@@ -131,7 +131,7 @@ const DisplaySettingsDialog: React.FC<DisplaySettingsDialogProps> = (
             numberOfColumnsPerPage: numberOfColumnsResults.right,
             fontSize: fontSizeResults.right,
             columnMargin: columnMarginResults.right,
-            scrollWidth: settings.scrollWidth,
+            scrollType: settings.scrollType,
         };
 
         return right(displaySettings);
@@ -152,7 +152,7 @@ const DisplaySettingsDialog: React.FC<DisplaySettingsDialogProps> = (
             numberOfColumnsPerPage: settings.right.numberOfColumnsPerPage,
             fontSize: settings.right.fontSize,
             columnMargin: settings.right.columnMargin,
-            scrollWidth: settings.right.scrollWidth,
+            scrollType: settings.right.scrollType,
         });
     };
 
@@ -236,7 +236,7 @@ const DisplaySettingsDialog: React.FC<DisplaySettingsDialogProps> = (
 
             setSettings({
                 ...settings,
-                scrollWidth: value,
+                scrollType: value,
             });
         };
 
@@ -245,7 +245,7 @@ const DisplaySettingsDialog: React.FC<DisplaySettingsDialogProps> = (
                 <FormControl component="fieldset">
                     <FormLabel>scroll type</FormLabel>
                     <RadioGroup
-                        value={settings.scrollWidth}
+                        value={settings.scrollType}
                         onChange={handleScrollTypeChange}
                     >
                         <FormControlLabel

--- a/src/components/play/Play.tsx
+++ b/src/components/play/Play.tsx
@@ -26,7 +26,7 @@ const Play: React.FC<PlayProps> = (props: PlayProps): JSX.Element => {
         numberOfColumnsPerPage: 2,
         fontSize: 14,
         columnMargin: 20,
-        scrollWidth: "page",
+        scrollType: "page",
     });
 
     const transparentStyle = useTransparentStyle();

--- a/src/components/play/Play.tsx
+++ b/src/components/play/Play.tsx
@@ -26,6 +26,7 @@ const Play: React.FC<PlayProps> = (props: PlayProps): JSX.Element => {
         numberOfColumnsPerPage: 2,
         fontSize: 14,
         columnMargin: 20,
+        scrollWidth: "page",
     });
 
     const transparentStyle = useTransparentStyle();

--- a/src/components/play/PlayContent.tsx
+++ b/src/components/play/PlayContent.tsx
@@ -13,6 +13,7 @@ export interface DisplaySettings {
     numberOfColumnsPerPage: number;
     fontSize: number;
     columnMargin: number;
+    scrollWidth: "page" | "column";
 }
 
 interface PlayContentProps {
@@ -43,7 +44,13 @@ const PlayContent: React.FC<PlayContentProps> = (
     const scrollPage = useCallback(
         (forward: boolean) => {
             const currentPos = window.scrollX;
-            const delta = forward ? windowWidth : -windowWidth;
+            const delta: number = (() => {
+                const scrollDelta =
+                    props.displaySettings.scrollWidth === "column"
+                        ? columnWidth
+                        : windowWidth;
+                return forward ? scrollDelta : -scrollDelta;
+            })();
 
             let nextPos = currentPos + delta;
 
@@ -62,7 +69,12 @@ const PlayContent: React.FC<PlayContentProps> = (
                 behavior: "smooth",
             });
         },
-        [columnWidth, windowWidth, snapThreshold]
+        [
+            columnWidth,
+            windowWidth,
+            snapThreshold,
+            props.displaySettings.scrollWidth,
+        ]
     );
 
     const scrollForward = useCallback(() => scrollPage(true), [scrollPage]);

--- a/src/components/play/PlayContent.tsx
+++ b/src/components/play/PlayContent.tsx
@@ -13,7 +13,7 @@ export interface DisplaySettings {
     numberOfColumnsPerPage: number;
     fontSize: number;
     columnMargin: number;
-    scrollWidth: "page" | "column";
+    scrollType: "page" | "column";
 }
 
 interface PlayContentProps {
@@ -46,7 +46,7 @@ const PlayContent: React.FC<PlayContentProps> = (
             const currentPos = window.scrollX;
             const delta: number = (() => {
                 const scrollDelta =
-                    props.displaySettings.scrollWidth === "column"
+                    props.displaySettings.scrollType === "column"
                         ? columnWidth
                         : windowWidth;
                 return forward ? scrollDelta : -scrollDelta;
@@ -73,7 +73,7 @@ const PlayContent: React.FC<PlayContentProps> = (
             columnWidth,
             windowWidth,
             snapThreshold,
-            props.displaySettings.scrollWidth,
+            props.displaySettings.scrollType,
         ]
     );
 


### PR DESCRIPTION
Adding an option to scroll one column at a time instead of one page at time - this requires the user to do more scrolling actions to get through the song but would allow a healthy amount of lookahead so that the next page isn't a surprise.