### PR TITLE
Fix: player resetting when hidden

### DIFF
--- a/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
@@ -43,7 +43,7 @@ type PlayerState<StemKey extends string> = {
     stems: StemState<StemKey>[];
 };
 
-interface StemInput<StemKey extends string> {
+export interface StemInput<StemKey extends string> {
     label: StemKey;
     buttonColour: ControlPaneButtonColour;
     audioBuffer: AudioBuffer;


### PR DESCRIPTION
Issue is because we've moved over to passing in the button specifications along with the audio buffers, the input array is created fresh on every render, so any props that trigger a rerender will cause the innards of the loaded player to change and replay the song from the beginning.

Fix is to rewrite it in a way that preserves referential equality by shoving the entire input into state as opposed to merging it right before, which creates a new object. Questionable fix...