### PR TITLE
Adding split track type

### DIFF
--- a/src/common/ChordModel/tracks/SplitStemRequest.ts
+++ b/src/common/ChordModel/tracks/SplitStemRequest.ts
@@ -1,0 +1,53 @@
+import * as iots from "io-ts";
+import { BaseTrackValidator, validateValue } from "./BaseTrack";
+
+export const SplitStemTrackValidator = iots.intersection([
+    BaseTrackValidator,
+    iots.type({
+        track_type: iots.union([
+            iots.literal("split_2stems"),
+            iots.literal("split_4stems"),
+            iots.literal("split_5stems"),
+        ]),
+        original_url: iots.string,
+    }),
+]);
+
+type SplitStemTrackValidatedFields = iots.TypeOf<
+    typeof SplitStemTrackValidator
+>;
+
+export type SplitStemTypes = "split_2stems" | "split_4stems" | "split_5stems";
+export class SplitStemTrack implements SplitStemTrackValidatedFields {
+    id: string;
+    track_type: SplitStemTypes;
+    label: string;
+    original_url: string;
+
+    constructor(
+        id: string,
+        label: string,
+        splitType: SplitStemTypes,
+        originalURL: string
+    ) {
+        this.id = id;
+        this.track_type = splitType;
+        this.label = label;
+        this.original_url = originalURL;
+    }
+
+    static fromValidatedFields(
+        validatedFields: SplitStemTrackValidatedFields
+    ): SplitStemTrack {
+        return new SplitStemTrack(
+            validatedFields.id,
+            validatedFields.label,
+            validatedFields.track_type,
+            validatedFields.original_url
+        );
+    }
+
+    validate(): boolean {
+        return validateValue(this.label) && validateValue(this.original_url);
+    }
+}

--- a/src/common/ChordModel/tracks/Track.ts
+++ b/src/common/ChordModel/tracks/Track.ts
@@ -1,5 +1,6 @@
 import * as iots from "io-ts";
 import { SingleTrack, SingleTrackValidator } from "./SingleTrack";
+import { SplitStemTrack, SplitStemTrackValidator } from "./SplitStemRequest";
 import {
     FiveStemTrack,
     FiveStemTrackValidator,
@@ -14,6 +15,12 @@ export const TrackValidator = iots.union([
     TwoStemTrackValidator,
     FourStemTrackValidator,
     FiveStemTrackValidator,
+    SplitStemTrackValidator,
 ]);
 
-export type Track = SingleTrack | TwoStemTrack | FourStemTrack | FiveStemTrack;
+export type Track =
+    | SingleTrack
+    | TwoStemTrack
+    | FourStemTrack
+    | FiveStemTrack
+    | SplitStemTrack;

--- a/src/common/ChordModel/tracks/TrackList.ts
+++ b/src/common/ChordModel/tracks/TrackList.ts
@@ -1,6 +1,7 @@
 import { Either, isLeft, left, right } from "fp-ts/lib/Either";
 import * as iots from "io-ts";
 import { SingleTrack } from "./SingleTrack";
+import { SplitStemTrack } from "./SplitStemRequest";
 import { FiveStemTrack, FourStemTrack, TwoStemTrack } from "./StemTrack";
 import { Track, TrackValidator } from "./Track";
 
@@ -40,6 +41,12 @@ export class TrackList implements TrackListValidatedFields {
 
                 case "5stems": {
                     return FiveStemTrack.fromValidatedFields(validatedFields);
+                }
+
+                case "split_2stems":
+                case "split_4stems":
+                case "split_5stems": {
+                    return SplitStemTrack.fromValidatedFields(validatedFields);
                 }
             }
         };

--- a/src/components/track_player/JamStation.tsx
+++ b/src/components/track_player/JamStation.tsx
@@ -15,7 +15,7 @@ interface JamStationProps {
     tracklistLoad: TrackListLoad;
     timeSections: TimeSection[];
     onTrackListChanged: (trackList: TrackList) => void;
-    onRefresh?: PlainFn;
+    onRefresh: PlainFn;
     collapsedButtonClassName?: string;
 }
 
@@ -148,6 +148,7 @@ const JamStation: React.FC<JamStationProps> = (
             currentTrackIndex={currentTrackIndex}
             onSelectCurrentTrack={setCurrentTrackIndex}
             onMinimize={minimizePlayer}
+            onRefresh={props.onRefresh}
             onOpenTrackEditDialog={openTrackEditDialog}
         />
     );

--- a/src/components/track_player/MultiTrackPlayer.tsx
+++ b/src/components/track_player/MultiTrackPlayer.tsx
@@ -12,7 +12,7 @@ import EditIcon from "@material-ui/icons/Edit";
 import CollapseDownIcon from "@material-ui/icons/ExpandMore";
 import RefreshIcon from "@material-ui/icons/Refresh";
 import { makeStyles, withStyles } from "@material-ui/styles";
-import React, { useRef } from "react";
+import React from "react";
 import { TimeSection } from "../../common/ChordModel/ChordLine";
 import { Track } from "../../common/ChordModel/tracks/Track";
 import { PlainFn } from "../../common/PlainFn";
@@ -23,7 +23,7 @@ import {
     withBottomRightBox,
 } from "./common";
 import { TrackListLoad } from "./TrackListProvider";
-import TrackPlayer, { Refreshable } from "./TrackPlayer";
+import TrackPlayer from "./TrackPlayer";
 
 const FlexBox = withStyles((theme: Theme) => ({
     root: {
@@ -72,13 +72,13 @@ interface MultiTrackPlayerProps {
 
     onOpenTrackEditDialog?: PlainFn;
     onMinimize: PlainFn;
+    onRefresh: PlainFn;
 }
 
 const MultiTrackPlayer: React.FC<MultiTrackPlayerProps> = (
     props: MultiTrackPlayerProps
 ): JSX.Element => {
     const paddingLeftStyle = usePaddingLeftStyle();
-    const refreshActionRef = useRef<Refreshable | null>(null);
 
     const trackListEditButton = props.onOpenTrackEditDialog !== undefined && (
         <TitleBarButton onClick={props.onOpenTrackEditDialog}>
@@ -86,10 +86,8 @@ const MultiTrackPlayer: React.FC<MultiTrackPlayerProps> = (
         </TitleBarButton>
     );
 
-    const refresh = () => refreshActionRef.current?.refresh();
-
     const trackRefreshButton = (
-        <TitleBarButton onClick={refresh}>
+        <TitleBarButton onClick={props.onRefresh}>
             <RefreshIcon />
         </TitleBarButton>
     );
@@ -162,12 +160,10 @@ const MultiTrackPlayer: React.FC<MultiTrackPlayerProps> = (
         const makePlayer = (track: Track, index: number) => {
             const currentTrack = index === props.currentTrackIndex;
             const show = currentTrack && props.show;
-            const ref = currentTrack ? refreshActionRef : undefined;
 
             return (
                 <TrackPlayer
                     key={`${index}-${track.id}`}
-                    refreshRef={ref}
                     show={show}
                     currentTrack={currentTrack}
                     track={track}

--- a/src/components/track_player/TrackPlayer.tsx
+++ b/src/components/track_player/TrackPlayer.tsx
@@ -1,6 +1,12 @@
-import { Collapse } from "@material-ui/core";
-import React, { useState } from "react";
-import shortid from "shortid";
+import {
+    Box,
+    Collapse,
+    LinearProgress,
+    Theme,
+    Typography,
+} from "@material-ui/core";
+import { withStyles } from "@material-ui/styles";
+import React from "react";
 import { TimeSection } from "../../common/ChordModel/ChordLine";
 import {
     FiveStemKeys,
@@ -8,21 +14,20 @@ import {
     TwoStemKeys,
 } from "../../common/ChordModel/tracks/StemTrack";
 import { Track } from "../../common/ChordModel/tracks/Track";
-import { PlainFn } from "../../common/PlainFn";
+import SingleTrackPlayer from "./internal_player/single/SingleTrackPlayer";
 import StemTrackPlayer, {
     StemButtonSpec,
 } from "./internal_player/stem/StemTrackPlayer";
-import SingleTrackPlayer from "./internal_player/single/SingleTrackPlayer";
 
-export interface Refreshable {
-    refresh: PlainFn;
-}
+const PaddedBox = withStyles((theme: Theme) => ({
+    root: {
+        margin: theme.spacing(3),
+    },
+}))(Box);
 
 interface TrackPlayerProps {
     show: boolean;
     currentTrack: boolean;
-    refreshRef?: React.MutableRefObject<Refreshable | null>;
-
     track: Track;
     readonly timeSections: TimeSection[];
 }
@@ -30,22 +35,11 @@ interface TrackPlayerProps {
 const TrackPlayer: React.FC<TrackPlayerProps> = (
     props: TrackPlayerProps
 ): JSX.Element => {
-    const [refreshToken, setRefreshToken] = useState(shortid.generate());
-
-    if (props.refreshRef !== undefined) {
-        props.refreshRef.current = {
-            refresh: () => {
-                setRefreshToken(shortid.generate());
-            },
-        };
-    }
-
     const innerPlayer: React.ReactElement = (() => {
         switch (props.track.track_type) {
             case "single": {
                 return (
                     <SingleTrackPlayer
-                        key={refreshToken}
                         show={props.show}
                         currentTrack={props.currentTrack}
                         track={props.track}
@@ -68,7 +62,6 @@ const TrackPlayer: React.FC<TrackPlayerProps> = (
 
                 return (
                     <StemTrackPlayer
-                        key={refreshToken}
                         show={props.show}
                         currentTrack={props.currentTrack}
                         track={props.track}
@@ -100,7 +93,6 @@ const TrackPlayer: React.FC<TrackPlayerProps> = (
 
                 return (
                     <StemTrackPlayer
-                        key={refreshToken}
                         show={props.show}
                         currentTrack={props.currentTrack}
                         track={props.track}
@@ -136,13 +128,25 @@ const TrackPlayer: React.FC<TrackPlayerProps> = (
 
                 return (
                     <StemTrackPlayer
-                        key={refreshToken}
                         show={props.show}
                         currentTrack={props.currentTrack}
                         track={props.track}
                         buttonSpecs={buttonSpecs}
                         timeSections={props.timeSections}
                     />
+                );
+            }
+
+            case "split_2stems":
+            case "split_4stems":
+            case "split_5stems": {
+                return (
+                    <PaddedBox>
+                        <Typography variant="body1">
+                            Processing track. Refresh to check progress.
+                        </Typography>
+                        <LinearProgress />
+                    </PaddedBox>
                 );
             }
         }

--- a/src/components/track_player/dialog/SplitStemTrackRow.tsx
+++ b/src/components/track_player/dialog/SplitStemTrackRow.tsx
@@ -1,0 +1,88 @@
+import { Button, Divider, Grid, Theme } from "@material-ui/core";
+import DeleteIcon from "@material-ui/icons/Delete";
+import { withStyles } from "@material-ui/styles";
+import lodash from "lodash";
+import React from "react";
+import { SplitStemTrack } from "../../../common/ChordModel/tracks/SplitStemRequest";
+import LabelField from "./LabelField";
+import URLField from "./URLField";
+
+interface SplitStemTrackRowProps {
+    track: SplitStemTrack;
+    onChange: (newTrack: SplitStemTrack) => void;
+    onRemove: () => void;
+}
+
+const RowContainer = withStyles((theme: Theme) => ({
+    root: {
+        margin: theme.spacing(2),
+    },
+}))(Grid);
+
+const SplitStemTrackRow: React.FC<SplitStemTrackRowProps> = (
+    props: SplitStemTrackRowProps
+): JSX.Element => {
+    const handleLabelChange = (newLabel: string) => {
+        const updatedTrack = lodash.clone(props.track);
+        updatedTrack.label = newLabel;
+        props.onChange(updatedTrack);
+    };
+
+    const handleURLChange = (newURL: string) => {
+        const updatedTrack = lodash.clone(props.track);
+        updatedTrack.original_url = newURL;
+        props.onChange(updatedTrack);
+    };
+
+    const currentlyProcessing = props.track.id !== "";
+
+    const urlLabelText: string = (() => {
+        if (currentlyProcessing) {
+            return "Processing track...";
+        }
+
+        switch (props.track.track_type) {
+            case "split_2stems": {
+                return "Track URL to be split into 2 stems";
+            }
+
+            case "split_4stems": {
+                return "Track URL to be split into 4 stems";
+            }
+
+            case "split_5stems": {
+                return "Track URL to be split into 5 stems";
+            }
+        }
+    })();
+
+    return (
+        <>
+            <RowContainer container alignItems="center">
+                <Grid xs={5} item>
+                    <LabelField
+                        value={props.track.label}
+                        onChange={handleLabelChange}
+                    />
+                </Grid>
+                <Grid xs={5} item>
+                    <URLField
+                        labelText={urlLabelText}
+                        value={props.track.original_url}
+                        onChange={handleURLChange}
+                        disabled={currentlyProcessing}
+                    />
+                </Grid>
+                <Grid xs={2} item>
+                    <Button onClick={props.onRemove}>
+                        <DeleteIcon />
+                    </Button>
+                </Grid>
+            </RowContainer>
+
+            <Divider />
+        </>
+    );
+};
+
+export default SplitStemTrackRow;

--- a/src/components/track_player/dialog/TrackListEditDialog.tsx
+++ b/src/components/track_player/dialog/TrackListEditDialog.tsx
@@ -34,6 +34,11 @@ import { PlainFn } from "../../../common/PlainFn";
 import { TrackListLoad } from "../TrackListProvider";
 import SingleTrackRow from "./SingleTrackRow";
 import StemTrackRow, { URLFieldLabel } from "./StemTrackRow";
+import SplitStemTrackRow from "./SplitStemTrackRow";
+import {
+    SplitStemTrack,
+    SplitStemTypes,
+} from "../../../common/ChordModel/tracks/SplitStemRequest";
 
 interface TrackListEditDialogProps {
     open: boolean;
@@ -180,6 +185,10 @@ const LoadedTrackListEditDialog: React.FC<LoadedTrackListEditDialogProps> = (
                 drums: "",
             })
         );
+    };
+
+    const handleAddSplitStemTrack = (splitType: SplitStemTypes) => {
+        handleAddTrack(new SplitStemTrack("", "", splitType, ""));
     };
 
     const handleAddTrack = (newTrack: Track) => {
@@ -341,6 +350,19 @@ const LoadedTrackListEditDialog: React.FC<LoadedTrackListEditDialogProps> = (
                             />
                         );
                     }
+
+                    case "split_2stems":
+                    case "split_4stems":
+                    case "split_5stems": {
+                        return (
+                            <SplitStemTrackRow
+                                key={rowKey}
+                                track={track}
+                                onChange={trackChangeHandler(index)}
+                                onRemove={() => removeTrack(index)}
+                            />
+                        );
+                    }
                 }
             }
         );
@@ -374,6 +396,21 @@ const LoadedTrackListEditDialog: React.FC<LoadedTrackListEditDialogProps> = (
                     </MenuItem>
                     <MenuItem onClick={handleAddFiveStemTrack}>
                         5 Stem Track
+                    </MenuItem>
+                    <MenuItem
+                        onClick={() => handleAddSplitStemTrack("split_2stems")}
+                    >
+                        Split Track into 2 Stems
+                    </MenuItem>
+                    <MenuItem
+                        onClick={() => handleAddSplitStemTrack("split_4stems")}
+                    >
+                        Split Track into 4 Stems
+                    </MenuItem>
+                    <MenuItem
+                        onClick={() => handleAddSplitStemTrack("split_5stems")}
+                    >
+                        Split Track into 5 Stems
                     </MenuItem>
                 </Menu>
             </React.Fragment>

--- a/src/components/track_player/dialog/URLField.tsx
+++ b/src/components/track_player/dialog/URLField.tsx
@@ -7,6 +7,7 @@ interface URLFieldProps {
     labelText: string;
     value: string;
     onChange: (newValue: string) => void;
+    disabled?: boolean;
 }
 
 const URLField: React.FC<URLFieldProps> = (
@@ -47,6 +48,7 @@ const URLField: React.FC<URLFieldProps> = (
             value={props.value}
             onChange={handleChange}
             onKeyDown={handleKey}
+            disabled={props.disabled}
             {...textFieldValidation(props.value)}
         />
     );


### PR DESCRIPTION
Adding new track types, which represent requests to the backend to split a song up into stems.

Also changing refresh button to simply refresh the whole tracklist as opposed to just rerendering a player.