### PR TITLE
Fix: player time context for labels not working

### DIFF
--- a/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
@@ -21,7 +21,11 @@ const SingleTrackPlayer: React.FC<SingleTrackPlayerProps> = (
 ): JSX.Element => {
     const playerRef = useRef<ReactPlayer>();
     const [playratePercentage, setPlayratePercentage] = useState(100);
-    const timeControl = useTimeControls(playerRef.current, props.timeSections);
+    const timeControl = useTimeControls(
+        props.show,
+        playerRef.current,
+        props.timeSections
+    );
     const trackURL: string = useMemo(
         () => ensureGoogleDriveCacheBusted(props.track.url, shortid.generate()),
         [props.track.url]

--- a/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
@@ -91,7 +91,11 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
     props: LoadedStemTrackPlayerProps<StemKey>
 ): JSX.Element => {
     const playerRef = useRef<FilePlayer>();
-    const timeControl = useTimeControls(playerRef.current, props.timeSections);
+    const timeControl = useTimeControls(
+        props.show,
+        playerRef.current,
+        props.timeSections
+    );
     const { enqueueSnackbar } = useSnackbar();
 
     const toneNodes: ToneNodes<StemKey> = useMemo(

--- a/src/components/track_player/internal_player/useTimeControls.ts
+++ b/src/components/track_player/internal_player/useTimeControls.ts
@@ -34,6 +34,7 @@ export interface TimeControls {
 }
 
 export const useTimeControls = (
+    focused: boolean,
     currentPlayerRef: ReactPlayer | FilePlayer | undefined,
     timeSections: TimeSection[]
 ): TimeControls => {
@@ -58,8 +59,10 @@ export const useTimeControls = (
         const getCurrentTime = () => currentTimeRef.current;
 
         useEffect(() => {
-            getPlayerTimeRef.current = getCurrentTime;
-        });
+            if (focused) {
+                getPlayerTimeRef.current = getCurrentTime;
+            }
+        }, [focused, getPlayerTimeRef, getCurrentTime]);
     }
 
     const seekTo = (time: number) => {
@@ -237,6 +240,7 @@ export const useTimeControls = (
         loaded: number;
         loadedSeconds: number;
     }) => {
+        console.log("setting progress to ", state.playedSeconds);
         setCurrentTime(state.playedSeconds);
     };
 


### PR DESCRIPTION
Auto time insertion for section labels weren't working because the get time fn was being overridden by other players - this didn't happen before but it was probably just serendipity by the ordering of rendering. Now that it's changed, it's obvious that it needs to be guarded by focused - only the focused player should set the time context.