### PR TITLE
Improve hotkey experience

### DIFF
--- a/src/components/play/PlayContent.tsx
+++ b/src/components/play/PlayContent.tsx
@@ -189,10 +189,15 @@ const PlayContent: React.FC<PlayContentProps> = (
 
     useEffect(() => {
         const handleKey = (event: KeyboardEvent) => {
-            // only fire for "default" targets, when the user isn't particularly interacting
-            // with anything else
-            if (event.target !== document.body) {
-                return;
+            // do not fire for any typing contexts
+            if (event.target instanceof HTMLElement) {
+                if (
+                    event.target.tagName === "INPUT" ||
+                    event.target.tagName === "TEXTAREA" ||
+                    event.target.isContentEditable
+                ) {
+                    return;
+                }
             }
 
             if (isScrollBackwardsKey(event.code)) {

--- a/src/components/track_player/internal_player/ControlPane.tsx
+++ b/src/components/track_player/internal_player/ControlPane.tsx
@@ -49,10 +49,15 @@ const ControlPane: React.FC<ControlPaneProps> = (
         }
 
         const handleKey = (event: KeyboardEvent) => {
-            // only fire for "default" targets, when the user isn't particularly interacting
-            // with anything else
-            if (event.target !== document.body) {
-                return;
+            // do not fire for any typing contexts
+            if (event.target instanceof HTMLElement) {
+                if (
+                    event.target.tagName === "INPUT" ||
+                    event.target.tagName === "TEXTAREA" ||
+                    event.target.isContentEditable
+                ) {
+                    return;
+                }
             }
 
             const stopEvent = () => {

--- a/src/components/track_player/internal_player/useTimeControls.ts
+++ b/src/components/track_player/internal_player/useTimeControls.ts
@@ -240,7 +240,6 @@ export const useTimeControls = (
         loaded: number;
         loadedSeconds: number;
     }) => {
-        console.log("setting progress to ", state.playedSeconds);
         setCurrentTime(state.playedSeconds);
     };
 


### PR DESCRIPTION
The hotkeys right now just sometimes work sporadically, depending on the focused element. It doesn't fire all the time because it would disable any sort of keyboard input. Improvement here is to just fire all the time, unless the event is targetted towards an input / contenteditable context.