### PR TITLE
Split line for reals

### DIFF
--- a/src/common/ChordModel/ChordBlock.ts
+++ b/src/common/ChordModel/ChordBlock.ts
@@ -85,9 +85,9 @@ export class ChordBlock implements IDable<ChordBlock> {
     // splitBlock(4) =>
     // {id:"B", chord: "B7", lyric:"my dear "}
     // {id:"A", chord: "", "we're"}
-    split(splitIndex: number): ChordBlock {
+    splitByTokenIndex(splitIndex: number): ChordBlock {
         if (splitIndex === 0) {
-            throw new Error("Split index can't be zero");
+            return new ChordBlock({ chord: "", lyric: new Lyric("") });
         }
 
         const tokens = this.lyricTokens;
@@ -105,11 +105,38 @@ export class ChordBlock implements IDable<ChordBlock> {
         return prevBlock;
     }
 
+    splitByCharIndex(splitIndex: number): ChordBlock {
+        if (splitIndex === 0) {
+            return new ChordBlock({ chord: "", lyric: new Lyric("") });
+        }
+
+        const lyricString: string = this.lyric.get((s: string) => s);
+        const prevBlockLyrics: Lyric = new Lyric(
+            lyricString.slice(0, splitIndex)
+        );
+        const thisBlockLyrics: Lyric = new Lyric(lyricString.slice(splitIndex));
+
+        const prevBlock: ChordBlock = new ChordBlock({
+            chord: this.chord,
+            lyric: prevBlockLyrics,
+        });
+
+        this.chord = "";
+        this.lyric = thisBlockLyrics;
+
+        return prevBlock;
+    }
+
     contentEquals(other: ChordBlock): boolean {
         return this.chord === other.chord && this.lyric.isEqual(other.lyric);
     }
 
     isEmpty(): boolean {
         return this.chord === "" && this.lyric.isEmpty();
+    }
+
+    lyricLength(): number {
+        const lyricString = this.lyric.get((s: string) => s);
+        return lyricString.length;
     }
 }

--- a/src/common/ChordModel/ChordBlock.ts
+++ b/src/common/ChordModel/ChordBlock.ts
@@ -87,7 +87,7 @@ export class ChordBlock implements IDable<ChordBlock> {
     // {id:"A", chord: "", "we're"}
     splitByTokenIndex(splitIndex: number): ChordBlock {
         if (splitIndex === 0) {
-            return new ChordBlock({ chord: "", lyric: new Lyric("") });
+            throw new Error("Split index can't be zero");
         }
 
         const tokens = this.lyricTokens;

--- a/src/common/ChordModel/ChordLine.ts
+++ b/src/common/ChordModel/ChordLine.ts
@@ -224,6 +224,30 @@ export class ChordLine extends Collection<ChordBlock>
         this.elements.splice(index, 0, newPrevBlock);
     }
 
+    splitByCharIndex(splitIndex: number): ChordLine {
+        if (splitIndex === 0) {
+            return new ChordLine();
+        }
+
+        for (let i = 0; i < this.elements.length; i++) {
+            const block = this.elements[i];
+            const lyricLength = block.lyricLength();
+
+            if (splitIndex - lyricLength > 0) {
+                //TODO
+                splitIndex -= lyricLength;
+                continue;
+            }
+
+            const lastBlockOfFirstHalf = block.splitByCharIndex(splitIndex);
+            const blocksOfPrevLine = this.elements.slice(0, i);
+            const blocksOfCurrLine = this.elements.slice(i);
+            blocksOfPrevLine.push(lastBlockOfFirstHalf);
+            this.elements = blocksOfCurrLine;
+            if (this.section) return new ChordLine();
+        }
+    }
+
     // passes through every block to ensure that blocks without chords exist (except for the first)
     normalizeBlocks(): void {
         const newBlocks: ChordBlock[] = [];

--- a/src/common/ChordModel/ChordLine.ts
+++ b/src/common/ChordModel/ChordLine.ts
@@ -220,7 +220,7 @@ export class ChordLine extends Collection<ChordBlock>
     splitBlock(idable: IDable<ChordBlock>, splitIndex: number): void {
         const index = this.indexOf(idable.id);
         const block = this.elements[index];
-        const newPrevBlock = block.split(splitIndex);
+        const newPrevBlock = block.splitByTokenIndex(splitIndex);
         this.elements.splice(index, 0, newPrevBlock);
     }
 

--- a/src/common/ChordModel/ChordSong.ts
+++ b/src/common/ChordModel/ChordSong.ts
@@ -277,6 +277,15 @@ export class ChordSong extends Collection<ChordLine>
         return true;
     }
 
+    splitLine(idable: IDable<ChordLine>, splitIndex: number): boolean {
+        const chordLine = this.get(idable);
+        const nextLine = chordLine.splitByCharIndex(splitIndex);
+
+        this.addAfter(chordLine, nextLine);
+
+        return true;
+    }
+
     contentEquals(other: ChordSong): boolean {
         if (this.chordLines.length !== other.chordLines.length) {
             return false;

--- a/src/common/ChordModel/test/ChordLine.test.ts
+++ b/src/common/ChordModel/test/ChordLine.test.ts
@@ -5,6 +5,11 @@ import { Lyric } from "../Lyric";
 
 const rawTextFn = (rawStr: string) => rawStr;
 
+const expectBlock = (block: ChordBlock, chord: string, lyric: string) => {
+    expect(block.chord).toEqual(chord);
+    expect(block.lyric.get(rawTextFn)).toEqual(lyric);
+};
+
 describe("ChordLine", () => {
     const testBlocks = (): ChordBlock[] => {
         return [
@@ -141,6 +146,70 @@ describe("ChordLine", () => {
 
             expect(c.chordBlocks[2].chord).toEqual("");
             expect(c.chordBlocks[2].lyric.get(rawTextFn)).toEqual(" to ");
+        });
+    });
+
+    describe("splitByCharIndex", () => {
+        test("split at beginning", () => {
+            const prevLine = c.splitByCharIndex(0);
+            expect(prevLine.section?.name).toEqual("Verse");
+            expect(prevLine.section?.type).toEqual("time");
+
+            expect(prevLine.elements.length).toEqual(1);
+            expectBlock(prevLine.elements[0], "", "");
+
+            expect(c.section).toEqual(undefined);
+
+            expect(c.elements.length).toEqual(3);
+            expectBlock(c.elements[0], "A7", "We're no ");
+            expectBlock(c.elements[1], "Bm", "strangers to ");
+            expectBlock(c.elements[2], "Cdim", "love");
+        });
+
+        test("split at block boundary", () => {
+            const prevLine = c.splitByCharIndex(9);
+            expect(prevLine.section?.name).toEqual("Verse");
+            expect(prevLine.section?.type).toEqual("time");
+
+            expect(prevLine.elements.length).toEqual(1);
+            expectBlock(prevLine.elements[0], "A7", "We're no ");
+
+            expect(c.section).toEqual(undefined);
+
+            expect(c.elements.length).toEqual(2);
+            expectBlock(c.elements[0], "Bm", "strangers to ");
+            expectBlock(c.elements[1], "Cdim", "love");
+        });
+
+        test("split at middle of block", () => {
+            const prevLine = c.splitByCharIndex(19);
+            expect(prevLine.section?.name).toEqual("Verse");
+            expect(prevLine.section?.type).toEqual("time");
+
+            expect(prevLine.elements.length).toEqual(2);
+            expectBlock(prevLine.elements[0], "A7", "We're no ");
+            expectBlock(prevLine.elements[1], "Bm", "strangers ");
+
+            expect(c.section).toEqual(undefined);
+
+            expect(c.elements.length).toEqual(2);
+            expectBlock(c.elements[0], "", "to ");
+            expectBlock(c.elements[1], "Cdim", "love");
+        });
+
+        test("split at end", () => {
+            const prevLine = c.splitByCharIndex(26);
+            expect(prevLine.section?.name).toEqual("Verse");
+            expect(prevLine.section?.type).toEqual("time");
+
+            expect(prevLine.elements.length).toEqual(3);
+            expectBlock(prevLine.elements[0], "A7", "We're no ");
+            expectBlock(prevLine.elements[1], "Bm", "strangers to ");
+            expectBlock(prevLine.elements[2], "Cdim", "love");
+
+            expect(c.section).toEqual(undefined);
+            expect(c.elements.length).toEqual(1);
+            expectBlock(c.elements[0], "", "");
         });
     });
 

--- a/src/common/ChordModel/test/ChordLine.test.ts
+++ b/src/common/ChordModel/test/ChordLine.test.ts
@@ -151,65 +151,65 @@ describe("ChordLine", () => {
 
     describe("splitByCharIndex", () => {
         test("split at beginning", () => {
-            const prevLine = c.splitByCharIndex(0);
-            expect(prevLine.section?.name).toEqual("Verse");
-            expect(prevLine.section?.type).toEqual("time");
+            const nextLine = c.splitByCharIndex(0);
+            expect(c.section?.name).toEqual("Verse");
+            expect(c.section?.type).toEqual("time");
 
-            expect(prevLine.elements.length).toEqual(1);
-            expectBlock(prevLine.elements[0], "", "");
+            expect(c.elements.length).toEqual(1);
+            expectBlock(c.elements[0], "", "");
 
-            expect(c.section).toEqual(undefined);
+            expect(nextLine.section).toEqual(undefined);
+
+            expect(nextLine.elements.length).toEqual(3);
+            expectBlock(nextLine.elements[0], "A7", "We're no ");
+            expectBlock(nextLine.elements[1], "Bm", "strangers to ");
+            expectBlock(nextLine.elements[2], "Cdim", "love");
+        });
+
+        test("split at block boundary", () => {
+            const nextLine = c.splitByCharIndex(9);
+            expect(c.section?.name).toEqual("Verse");
+            expect(c.section?.type).toEqual("time");
+
+            expect(c.elements.length).toEqual(1);
+            expectBlock(c.elements[0], "A7", "We're no ");
+
+            expect(nextLine.section).toEqual(undefined);
+
+            expect(nextLine.elements.length).toEqual(2);
+            expectBlock(nextLine.elements[0], "Bm", "strangers to ");
+            expectBlock(nextLine.elements[1], "Cdim", "love");
+        });
+
+        test("split at middle of block", () => {
+            const nextLine = c.splitByCharIndex(19);
+            expect(c.section?.name).toEqual("Verse");
+            expect(c.section?.type).toEqual("time");
+
+            expect(c.elements.length).toEqual(2);
+            expectBlock(c.elements[0], "A7", "We're no ");
+            expectBlock(c.elements[1], "Bm", "strangers ");
+
+            expect(nextLine.section).toEqual(undefined);
+
+            expect(nextLine.elements.length).toEqual(2);
+            expectBlock(nextLine.elements[0], "", "to ");
+            expectBlock(nextLine.elements[1], "Cdim", "love");
+        });
+
+        test("split at end", () => {
+            const nextLine = c.splitByCharIndex(26);
+            expect(c.section?.name).toEqual("Verse");
+            expect(c.section?.type).toEqual("time");
 
             expect(c.elements.length).toEqual(3);
             expectBlock(c.elements[0], "A7", "We're no ");
             expectBlock(c.elements[1], "Bm", "strangers to ");
             expectBlock(c.elements[2], "Cdim", "love");
-        });
 
-        test("split at block boundary", () => {
-            const prevLine = c.splitByCharIndex(9);
-            expect(prevLine.section?.name).toEqual("Verse");
-            expect(prevLine.section?.type).toEqual("time");
-
-            expect(prevLine.elements.length).toEqual(1);
-            expectBlock(prevLine.elements[0], "A7", "We're no ");
-
-            expect(c.section).toEqual(undefined);
-
-            expect(c.elements.length).toEqual(2);
-            expectBlock(c.elements[0], "Bm", "strangers to ");
-            expectBlock(c.elements[1], "Cdim", "love");
-        });
-
-        test("split at middle of block", () => {
-            const prevLine = c.splitByCharIndex(19);
-            expect(prevLine.section?.name).toEqual("Verse");
-            expect(prevLine.section?.type).toEqual("time");
-
-            expect(prevLine.elements.length).toEqual(2);
-            expectBlock(prevLine.elements[0], "A7", "We're no ");
-            expectBlock(prevLine.elements[1], "Bm", "strangers ");
-
-            expect(c.section).toEqual(undefined);
-
-            expect(c.elements.length).toEqual(2);
-            expectBlock(c.elements[0], "", "to ");
-            expectBlock(c.elements[1], "Cdim", "love");
-        });
-
-        test("split at end", () => {
-            const prevLine = c.splitByCharIndex(26);
-            expect(prevLine.section?.name).toEqual("Verse");
-            expect(prevLine.section?.type).toEqual("time");
-
-            expect(prevLine.elements.length).toEqual(3);
-            expectBlock(prevLine.elements[0], "A7", "We're no ");
-            expectBlock(prevLine.elements[1], "Bm", "strangers to ");
-            expectBlock(prevLine.elements[2], "Cdim", "love");
-
-            expect(c.section).toEqual(undefined);
-            expect(c.elements.length).toEqual(1);
-            expectBlock(c.elements[0], "", "");
+            expect(nextLine.section).toEqual(undefined);
+            expect(nextLine.elements.length).toEqual(1);
+            expectBlock(nextLine.elements[0], "", "");
         });
     });
 

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -123,6 +123,17 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
         return false;
     };
 
+    const splitLine = (id: IDable<ChordLine>, splitIndex: number): boolean => {
+        const didSplit = props.song.splitLine(id, splitIndex);
+
+        if (didSplit) {
+            notifySongChanged();
+            return true;
+        }
+
+        return false;
+    };
+
     const notifySongChanged = () => {
         props.onSongChanged?.(props.song);
     };
@@ -177,6 +188,7 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
                         onChangeLine={handleChangeLine}
                         onJSONPaste={handleJSONPaste}
                         onLyricOverflow={handleLyricOverflow}
+                        onSplitLine={splitLine}
                         onMergeWithPreviousLine={mergeWithPreviousLine}
                         onChordDragAndDrop={handleChordDND}
                         data-testid={`Line-${index}`}

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -46,6 +46,7 @@ interface LineProps extends DataTestID {
     ) => void;
     onJSONPaste?: (id: IDable<ChordLine>, jsonStr: string) => boolean;
     onMergeWithPreviousLine?: (id: IDable<ChordLine>) => boolean;
+    onSplitLine?: (id: IDable<ChordLine>, splitIndex: number) => boolean;
     onChordDragAndDrop?: BlockProps["onChordDragAndDrop"];
 }
 
@@ -120,6 +121,7 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
             onChangeLine={props.onChangeLine}
             onJSONPaste={props.onJSONPaste}
             onMergeWithPreviousLine={props.onMergeWithPreviousLine}
+            onSplitLine={props.onSplitLine}
             onLyricOverflow={props.onLyricOverflow}
         >
             {(startEdit: PlainFn) => withHoverMenu(startEdit, menuItems)}

--- a/src/components/edit/WithLyricInput.tsx
+++ b/src/components/edit/WithLyricInput.tsx
@@ -2,11 +2,11 @@ import { Box, Theme, withStyles } from "@material-ui/core";
 import React from "react";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { IDable } from "../../common/ChordModel/Collection";
+import { Lyric } from "../../common/ChordModel/Lyric";
 import { PlainFn } from "../../common/PlainFn";
 import { lyricStyle, lyricTypographyVariant } from "../display/Lyric";
 import { useEditingState } from "./InteractionContext";
 import UnstyledLyricInput from "./lyric_input/LyricInput";
-import { Lyric } from "../../common/ChordModel/Lyric";
 
 const LyricInput = withStyles((theme: Theme) => ({
     root: {
@@ -24,6 +24,7 @@ interface WithLyricInputProps {
     onLyricOverflow?: (id: IDable<ChordLine>, overflowLyric: Lyric[]) => void;
     onJSONPaste?: (id: IDable<ChordLine>, jsonStr: string) => boolean;
     onMergeWithPreviousLine?: (id: IDable<ChordLine>) => boolean;
+    onSplitLine?: (id: IDable<ChordLine>, splitIndex: number) => boolean;
 }
 
 // this component is inherently quite coupled with Line & friends
@@ -63,6 +64,14 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
                 }
             }
         },
+        specialEnter: (splitIndex: number) => {
+            if (props.onSplitLine) {
+                const handled = props.onSplitLine(props.chordLine, splitIndex);
+                if (handled) {
+                    finishEdit();
+                }
+            }
+        },
     };
 
     const lineElement: React.ReactElement = props.children(startEdit);
@@ -83,6 +92,7 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
                     onJSONPaste={handlers.jsonPaste}
                     onLyricOverflow={handlers.pasteOverflow}
                     onSpecialBackspace={handlers.specialBackspace}
+                    onSpecialEnter={handlers.specialEnter}
                 >
                     {props.chordLine.lyrics}
                 </LyricInput>

--- a/src/components/edit/lyric_input/LyricInput.tsx
+++ b/src/components/edit/lyric_input/LyricInput.tsx
@@ -41,6 +41,7 @@ interface LyricInputProps extends StyledComponentProps {
     children: Lyric;
     onFinish: (newValue: Lyric) => void;
     onSpecialBackspace: PlainFn;
+    onSpecialEnter: (splitIndex: number) => void;
     onLyricOverflow: (overflowContent: Lyric[]) => void;
     onJSONPaste: (jsonStr: string) => boolean;
     variant?: TypographyVariant;
@@ -72,12 +73,9 @@ const LyricInput: React.FC<LyricInputProps> = (
         specialBackspaceCallback: () => {
             props.onSpecialBackspace();
         },
-        specialEnterCallback: (
-            beforeSelection: Lyric,
-            afterSelection: Lyric
-        ) => {
-            finish(beforeSelection);
-            props.onLyricOverflow([afterSelection]);
+        specialEnterCallback: (splitIndex: number) => {
+            finish(value());
+            props.onSpecialEnter(splitIndex);
         },
     };
 


### PR DESCRIPTION
CTRL/CMD + enter to split the line at the cursor - this already existed, but was incorrectly implemented out of lack of usecase and effort - it would just split the lyrics and leave the chords behind on the first line.

This implementation actually cuts the line in half and splits it - it was a recurring painpoint when the user would need to divide up the line differently after transcribing harmony had started