### PR TITLE
Fix: Keyboard pause doesn't work sometimes

### DIFF
--- a/src/components/GlobalKeyListener.tsx
+++ b/src/components/GlobalKeyListener.tsx
@@ -53,22 +53,23 @@ const GlobalKeyListenerProvider: React.FC<GlobalKeyListenerProviderProps> = (
     };
 
     const wrapListener = (listener: KeyListener): KeyListener => {
-        return (event: KeyboardEvent) => {
-            // do not fire for any typing contexts
-            if (event.target instanceof HTMLElement) {
-                if (
-                    event.target.tagName === "INPUT" ||
+        return (event: KeyboardEvent): void => {
+            const isTypingContext =
+                event.target instanceof HTMLElement &&
+                (event.target.tagName === "INPUT" ||
                     event.target.tagName === "TEXTAREA" ||
-                    event.target.isContentEditable
-                ) {
-                    return;
-                }
+                    event.target.isContentEditable);
+
+            if (isTypingContext) {
+                return;
             }
 
             listener(event);
+
             if (event.defaultPrevented) {
                 event.stopImmediatePropagation();
             }
+            return;
         };
     };
 

--- a/src/components/track_player/internal_player/reactPlayerProps.ts
+++ b/src/components/track_player/internal_player/reactPlayerProps.ts
@@ -1,0 +1,61 @@
+import { ReactEventHandler } from "react";
+import { ReactPlayerProps } from "react-player";
+import { BaseReactPlayerProps } from "react-player/base";
+import { FilePlayerProps } from "react-player/file";
+import { PlayerControls } from "./usePlayerControls";
+
+const makeBasePlayerProps = (
+    playerControls: PlayerControls
+): BaseReactPlayerProps => {
+    return {
+        ref: playerControls.playerRef,
+        playing: playerControls.playing,
+        controls: true,
+        playbackRate: playerControls.playratePercentage / 100,
+        onPlay: playerControls.onPlay,
+        onPause: playerControls.onPause,
+        onProgress: playerControls.onProgress,
+        progressInterval: 500,
+        style: { minWidth: "50vw" },
+        height: "auto",
+        onKeyUp: (event: KeyboardEvent) => event.preventDefault(),
+    };
+};
+
+export const makeFilePlayerProps = (
+    playerControls: PlayerControls,
+    masterVolumePercentage: number,
+    onVolumeChange?: ReactEventHandler<HTMLAudioElement>
+): FilePlayerProps => {
+    const attributes = (() => {
+        if (onVolumeChange === undefined) {
+            return undefined;
+        }
+
+        return {
+            onVolumeChange: onVolumeChange,
+        };
+    })();
+
+    const basePlayerProps = makeBasePlayerProps(playerControls);
+
+    return {
+        ...basePlayerProps,
+        volume: masterVolumePercentage / 100,
+        config: {
+            forceAudio: true,
+            attributes: attributes,
+        },
+    };
+};
+
+export const makeReactPlayerProps = (
+    playerControls: PlayerControls
+): ReactPlayerProps => {
+    const basePlayerProps = makeBasePlayerProps(playerControls);
+
+    return {
+        ...basePlayerProps,
+        config: { file: { forceAudio: true } },
+    };
+};

--- a/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
@@ -5,6 +5,7 @@ import shortid from "shortid";
 import { SingleTrack } from "../../../../common/ChordModel/tracks/SingleTrack";
 import ControlPane from "../ControlPane";
 import { ensureGoogleDriveCacheBusted } from "../google_drive";
+import { makeReactPlayerProps } from "../reactPlayerProps";
 import { PlayerControls } from "../usePlayerControls";
 
 interface SingleTrackPlayerProps {
@@ -22,19 +23,9 @@ const SingleTrackPlayer: React.FC<SingleTrackPlayerProps> = (
         [props.track.url]
     );
 
-    const commonReactPlayerProps: ReactPlayerProps = {
-        ref: props.playerControls.playerRef,
-        playing: props.playerControls.playing,
-        controls: true,
-        playbackRate: props.playerControls.playratePercentage / 100,
-        onPlay: props.playerControls.onPlay,
-        onPause: props.playerControls.onPause,
-        onProgress: props.playerControls.onProgress,
-        progressInterval: 500,
-        style: { minWidth: "50vw" },
-        height: "auto",
-        config: { file: { forceAudio: true } },
-    };
+    const reactPlayerProps: ReactPlayerProps = makeReactPlayerProps(
+        props.playerControls
+    );
 
     useEffect(() => {
         if (!props.currentTrack && props.playerControls.playing) {
@@ -45,7 +36,7 @@ const SingleTrackPlayer: React.FC<SingleTrackPlayerProps> = (
     return (
         <Box>
             <Box>
-                <ReactPlayer {...commonReactPlayerProps} url={trackURL} />
+                <ReactPlayer {...reactPlayerProps} url={trackURL} />
             </Box>
             <ControlPane
                 show={props.focused}

--- a/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
@@ -10,9 +10,10 @@ import React, {
     useRef,
     useState,
 } from "react";
-import FilePlayer, { FilePlayerProps } from "react-player/file";
+import FilePlayer from "react-player/file";
 import * as Tone from "tone";
 import ControlPane from "../ControlPane";
+import { makeFilePlayerProps } from "../reactPlayerProps";
 import { PlayerControls } from "../usePlayerControls";
 import { getAudioCtx } from "./audioCtx";
 import StemTrackControlPane, {
@@ -112,9 +113,8 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
         };
     })();
 
-    const [playerState, setPlayerState] = useState<PlayerState<StemKey>>(
-        initialPlayerState
-    );
+    const [playerState, setPlayerState] =
+        useState<PlayerState<StemKey>>(initialPlayerState);
 
     const playerStateRef = useRef(playerState);
     playerStateRef.current = playerState;
@@ -137,25 +137,11 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
         setPlayerState(newPlayerState);
     };
 
-    const commonReactPlayerProps: FilePlayerProps = {
-        ref: props.playerControls.playerRef,
-        playing: props.playerControls.playing,
-        controls: true,
-        volume: playerState.masterVolumePercentage / 100,
-        playbackRate: props.playerControls.playratePercentage / 100,
-        onPlay: props.playerControls.onPlay,
-        onPause: props.playerControls.onPause,
-        onProgress: props.playerControls.onProgress,
-        progressInterval: 500,
-        style: { minWidth: "50vw" },
-        height: "auto",
-        config: {
-            forceAudio: true,
-            attributes: {
-                onVolumeChange: handleMasterVolumeChange,
-            },
-        },
-    };
+    const filePlayerProps = makeFilePlayerProps(
+        props.playerControls,
+        playerState.masterVolumePercentage,
+        handleMasterVolumeChange
+    );
 
     // check the integrity of the loaded tracks - they should all be the same length
     // otherwise there could be a loading error
@@ -308,9 +294,8 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
                 volume: stemState.volumePercentage,
                 onVolumeChanged: (newVolume: number) => {
                     const newPlayerState = lodash.cloneDeep(playerState);
-                    newPlayerState.stems[
-                        stemIndex
-                    ].volumePercentage = newVolume;
+                    newPlayerState.stems[stemIndex].volumePercentage =
+                        newVolume;
                     setPlayerState(newPlayerState);
                 },
             };
@@ -324,7 +309,7 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
     return (
         <Box>
             <Box>
-                <FilePlayer {...commonReactPlayerProps} url={silentURL} />
+                <FilePlayer {...filePlayerProps} url={silentURL} />
             </Box>
             {stemControlPane}
             <ControlPane


### PR DESCRIPTION
Some confusing coupling going on here...

Issue: pressing space to pause on the keyboard doesn't work as it should sometimes if the last focus was still on the audio element - it would pause and then unpause because the key handlers and audio element would both toggle the play state.

Fix here is to prevent default on all keyups for the react player. Might be a bit aggressive, but we're already intercepting the keys on keydown.