### PR TITLE
Track Player: Transpose keys

### DIFF
--- a/src/components/track_player/internal_player/ControlButton.tsx
+++ b/src/components/track_player/internal_player/ControlButton.tsx
@@ -1,7 +1,7 @@
 import { Button as UnstyledButton, Theme, Tooltip } from "@material-ui/core";
 import { ButtonProps } from "@material-ui/core/Button";
-import DecreasePlayrateIcon from "@material-ui/icons/ArrowDropDown";
-import IncreasePlayrateIcon from "@material-ui/icons/ArrowDropUp";
+import DecreaseIcon from "@material-ui/icons/ArrowDropDown";
+import IncreaseIcon from "@material-ui/icons/ArrowDropUp";
 import PauseIcon from "@material-ui/icons/Pause";
 import PlayIcon from "@material-ui/icons/PlayArrow";
 import JumpBackIcon from "@material-ui/icons/Replay";
@@ -95,15 +95,27 @@ export const ControlButton = {
         "primary"
     ),
     DecreasePlayrate: makeControlButton(
-        <DecreasePlayrateIcon />,
+        <DecreaseIcon />,
         "decrease-playrate-button",
         "Play slower",
         "primary"
     ),
     IncreasePlayrate: makeControlButton(
-        <IncreasePlayrateIcon />,
+        <IncreaseIcon />,
         "increase-playrate-button",
         "Play faster",
+        "primary"
+    ),
+    TransposeDown: makeControlButton(
+        <DecreaseIcon />,
+        "transpose-down-button",
+        "Transpose down half step",
+        "primary"
+    ),
+    TransposeUp: makeControlButton(
+        <IncreaseIcon />,
+        "transpose-up-button",
+        "Transpose up half step",
         "primary"
     ),
 };

--- a/src/components/track_player/internal_player/ControlGroup.tsx
+++ b/src/components/track_player/internal_player/ControlGroup.tsx
@@ -28,27 +28,18 @@ const ControlGroup: React.FC<ControlGroupProps> = (
 ): JSX.Element => {
     const contents: React.ReactElement[] = props.children.map(
         (child: React.ReactNode, index: number) => {
-            const content: React.ReactNode[] = (() => {
-                if (props.dividers === "right") {
-                    return [
-                        child,
-                        <VerticalMiddleDivider
-                            key={`divider-${index}`}
-                            orientation="vertical"
-                            flexItem
-                        />,
-                    ];
-                }
+            const divider = (
+                <VerticalMiddleDivider
+                    key={`divider-${index}`}
+                    orientation="vertical"
+                    flexItem
+                />
+            );
 
-                return [
-                    <VerticalMiddleDivider
-                        key={`divider-${index}`}
-                        orientation="vertical"
-                        flexItem
-                    />,
-                    child,
-                ];
-            })();
+            const content: React.ReactNode[] =
+                props.dividers === "right"
+                    ? [child, divider]
+                    : [divider, child];
 
             return <React.Fragment key={index}>{content}</React.Fragment>;
         }

--- a/src/components/track_player/internal_player/ControlGroup.tsx
+++ b/src/components/track_player/internal_player/ControlGroup.tsx
@@ -19,24 +19,38 @@ export const VerticalMiddleDivider = withStyles((theme: Theme) => ({
 }))(Divider);
 
 interface ControlGroupProps {
-    children: React.ReactElement[];
+    children: React.ReactNode[];
+    dividers: "left" | "right";
 }
 
 const ControlGroup: React.FC<ControlGroupProps> = (
     props: ControlGroupProps
 ): JSX.Element => {
     const contents: React.ReactElement[] = props.children.map(
-        (child: React.ReactElement, index: number) => {
-            return (
-                <React.Fragment key={index}>
-                    {child}
+        (child: React.ReactNode, index: number) => {
+            const content: React.ReactNode[] = (() => {
+                if (props.dividers === "right") {
+                    return [
+                        child,
+                        <VerticalMiddleDivider
+                            key={`divider-${index}`}
+                            orientation="vertical"
+                            flexItem
+                        />,
+                    ];
+                }
+
+                return [
                     <VerticalMiddleDivider
                         key={`divider-${index}`}
                         orientation="vertical"
                         flexItem
-                    />
-                </React.Fragment>
-            );
+                    />,
+                    child,
+                ];
+            })();
+
+            return <React.Fragment key={index}>{content}</React.Fragment>;
         }
     );
 

--- a/src/components/track_player/internal_player/ControlPane.tsx
+++ b/src/components/track_player/internal_player/ControlPane.tsx
@@ -8,6 +8,7 @@ import { ControlButton } from "./ControlButton";
 import ControlGroup from "./ControlGroup";
 import PlayrateControl from "./PlayrateControl";
 import SectionLabel from "./SectionLabel";
+import TransposeControl from "./TransposeControl";
 import { ButtonActionAndState } from "./usePlayerControls";
 
 interface ControlPaneProps {
@@ -21,6 +22,10 @@ interface ControlPaneProps {
     onSkipForward: ButtonActionAndState;
     playratePercentage: number;
     onPlayratePercentageChange: (newPlayrate: number) => void;
+    transpose?: {
+        level: number;
+        onChange: (newLevel: number) => void;
+    };
     sectionLabel: string;
 }
 
@@ -84,9 +89,42 @@ const ControlPane: React.FC<ControlPaneProps> = (
         };
     }, [props, addTopKeyListener, removeKeyListener]);
 
+    const transposeControl: JSX.Element | null = (() => {
+        if (props.transpose === undefined) {
+            return null;
+        }
+
+        return (
+            <TransposeControl
+                transposeLevel={props.transpose.level}
+                onChange={props.transpose.onChange}
+            />
+        );
+    })();
+
+    const rightSideControls: JSX.Element = (() => {
+        const playrateControl = (
+            <PlayrateControl
+                playratePercentage={props.playratePercentage}
+                onChange={props.onPlayratePercentageChange}
+            />
+        );
+
+        if (transposeControl === null) {
+            return playrateControl;
+        }
+
+        return (
+            <ControlGroup dividers="left">
+                {transposeControl}
+                {playrateControl}
+            </ControlGroup>
+        );
+    })();
+
     return (
         <ControlPaneBox>
-            <ControlGroup>
+            <ControlGroup dividers="right">
                 <ControlButton.Beginning onClick={props.onGoToBeginning} />
                 <ControlButton.SkipBack
                     disabled={!props.onSkipBack.enabled}
@@ -101,10 +139,7 @@ const ControlPane: React.FC<ControlPaneProps> = (
                 />
             </ControlGroup>
             <SectionLabel value={props.sectionLabel} />
-            <PlayrateControl
-                playratePercentage={props.playratePercentage}
-                onChange={props.onPlayratePercentageChange}
-            />
+            {rightSideControls}
         </ControlPaneBox>
     );
 };

--- a/src/components/track_player/internal_player/ControlPane.tsx
+++ b/src/components/track_player/internal_player/ControlPane.tsx
@@ -20,8 +20,10 @@ interface ControlPaneProps {
     onGoToBeginning: PlainFn;
     onSkipBack: ButtonActionAndState;
     onSkipForward: ButtonActionAndState;
-    playratePercentage: number;
-    onPlayratePercentageChange: (newPlayrate: number) => void;
+    playrate: {
+        percentage: number;
+        onChange: (newPercentage: number) => void;
+    };
     transpose?: {
         level: number;
         onChange: (newLevel: number) => void;
@@ -105,8 +107,8 @@ const ControlPane: React.FC<ControlPaneProps> = (
     const rightSideControls: JSX.Element = (() => {
         const playrateControl = (
             <PlayrateControl
-                playratePercentage={props.playratePercentage}
-                onChange={props.onPlayratePercentageChange}
+                playratePercentage={props.playrate.percentage}
+                onChange={props.playrate.onChange}
             />
         );
 

--- a/src/components/track_player/internal_player/TransposeControl.tsx
+++ b/src/components/track_player/internal_player/TransposeControl.tsx
@@ -1,0 +1,73 @@
+import { Box, Theme, Tooltip, Typography } from "@material-ui/core";
+import { withStyles } from "@material-ui/styles";
+import React from "react";
+import { greyTextColour } from "../common";
+import { ControlButton } from "./ControlButton";
+import { ControlGroupBox } from "./ControlGroup";
+
+const TransposeBox = withStyles({
+    root: {
+        justifyContent: "space-between",
+    },
+})(ControlGroupBox);
+
+const TransposeDisplay = withStyles((theme: Theme) => {
+    return {
+        root: {
+            color: greyTextColour,
+            display: "flex",
+            justifyContent: "center",
+        },
+    };
+})(Typography);
+
+interface TransposeControlProps {
+    transposeLevel: number;
+    onChange: (newTransposeLevel: number) => void;
+}
+
+const TransposeControl: React.FC<TransposeControlProps> = (
+    props: TransposeControlProps
+): JSX.Element => {
+    const playrate = Math.round(props.transposeLevel);
+    const interval = 1;
+
+    const onDecrease = () => props.onChange(playrate - interval);
+    const onIncrease = () => props.onChange(playrate + interval);
+
+    const decreaseDisabled = playrate - interval < -12;
+    const increaseDisabled = playrate + interval > 12;
+
+    const transposeText: string = (() => {
+        if (props.transposeLevel > 0) {
+            return `♯${props.transposeLevel}`;
+        }
+
+        if (props.transposeLevel < 0) {
+            return `♭${-props.transposeLevel}`;
+        }
+
+        return "♮0";
+    })();
+
+    return (
+        <TransposeBox>
+            <ControlButton.TransposeDown
+                onClick={onDecrease}
+                disabled={decreaseDisabled}
+            />
+            <Tooltip title="Transposition">
+                <TransposeDisplay variant="h6">
+                    <Box>{transposeText}</Box>
+                </TransposeDisplay>
+            </Tooltip>
+
+            <ControlButton.TransposeUp
+                onClick={onIncrease}
+                disabled={increaseDisabled}
+            />
+        </TransposeBox>
+    );
+};
+
+export default TransposeControl;

--- a/src/components/track_player/internal_player/reactPlayerProps.ts
+++ b/src/components/track_player/internal_player/reactPlayerProps.ts
@@ -18,6 +18,7 @@ const makeBasePlayerProps = (
         progressInterval: 500,
         style: { minWidth: "50vw" },
         height: "auto",
+        width: "unset",
         onKeyUp: (event: KeyboardEvent) => event.preventDefault(),
     };
 };

--- a/src/components/track_player/internal_player/reactPlayerProps.ts
+++ b/src/components/track_player/internal_player/reactPlayerProps.ts
@@ -11,7 +11,7 @@ const makeBasePlayerProps = (
         ref: playerControls.playerRef,
         playing: playerControls.playing,
         controls: true,
-        playbackRate: playerControls.playratePercentage / 100,
+        playbackRate: playerControls.playrate.percentage / 100,
         onPlay: playerControls.onPlay,
         onPause: playerControls.onPause,
         onProgress: playerControls.onProgress,

--- a/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
@@ -48,10 +48,7 @@ const SingleTrackPlayer: React.FC<SingleTrackPlayerProps> = (
                 onSkipBack={props.playerControls.skipBack}
                 onSkipForward={props.playerControls.skipForward}
                 onGoToBeginning={props.playerControls.goToBeginning}
-                playratePercentage={props.playerControls.playratePercentage}
-                onPlayratePercentageChange={
-                    props.playerControls.onPlayratePercentageChange
-                }
+                playrate={props.playerControls.playrate}
             />
         </Box>
     );

--- a/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
@@ -193,7 +193,7 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
             Tone.Transport.pause();
         }
 
-        const playrate = props.playerControls.playratePercentage / 100;
+        const playrate = props.playerControls.playrate.percentage / 100;
 
         // Tone transport doesn't observe slowed down time, only each individual node plays the sound back slower
         // e.g. if a 10s clip is played at 50% speed, then Tone transport will finish playing it from 0s to 20s
@@ -208,7 +208,7 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
     }, [
         props.playerControls.playing,
         props.playerControls.currentTime,
-        props.playerControls.playratePercentage,
+        props.playerControls.playrate.percentage,
     ]);
 
     // synchronize player state and track volumes/mutedness
@@ -231,10 +231,10 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
                 node.endNode.mute = stemState.muted || stemVolume === 0;
 
                 node.playerNode.playbackRate =
-                    props.playerControls.playratePercentage / 100;
+                    props.playerControls.playrate.percentage / 100;
             }
         );
-    }, [toneNodes, playerState, props.playerControls.playratePercentage]);
+    }, [toneNodes, playerState, props.playerControls.playrate.percentage]);
 
     // synchronize player state and pitch shift
     useEffect(() => {
@@ -351,10 +351,7 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
                 onSkipBack={props.playerControls.skipBack}
                 onSkipForward={props.playerControls.skipForward}
                 onGoToBeginning={props.playerControls.goToBeginning}
-                playratePercentage={props.playerControls.playratePercentage}
-                onPlayratePercentageChange={
-                    props.playerControls.onPlayratePercentageChange
-                }
+                playrate={props.playerControls.playrate}
                 transpose={{
                     level: playerState.masterPitchShift,
                     onChange: handlePitchShift,

--- a/src/components/track_player/internal_player/usePlayerControls.ts
+++ b/src/components/track_player/internal_player/usePlayerControls.ts
@@ -31,8 +31,10 @@ export interface PlayerControls {
     onPlay: PlainFn;
     onPause: PlainFn;
     currentSectionLabel: string;
-    playratePercentage: number;
-    onPlayratePercentageChange: (val: number) => void;
+    playrate: {
+        percentage: number;
+        onChange: (val: number) => void;
+    };
 }
 
 class NoopMutableRef {
@@ -70,8 +72,10 @@ export const unfocusedControls: PlayerControls = {
     onPlay: voidFn,
     onPause: voidFn,
     currentSectionLabel: "",
-    playratePercentage: 100,
-    onPlayratePercentageChange: voidFn,
+    playrate: {
+        percentage: 100,
+        onChange: voidFn,
+    },
 };
 
 export const usePlayerControls = (
@@ -306,7 +310,9 @@ export const usePlayerControls = (
         onPlay: handlePlayState,
         onPause: handlePauseState,
         currentSectionLabel: currentSectionLabel,
-        playratePercentage: playratePercentage,
-        onPlayratePercentageChange: setPlayratePercentage,
+        playrate: {
+            percentage: playratePercentage,
+            onChange: setPlayratePercentage,
+        },
     };
 };


### PR DESCRIPTION
Adding key transposition to the audio portion of the player. This only works for the stem player since that's where we have control over the audio transformations.

Drums are exempt from this as a special case - drums transposed do not sound good.