### PR TITLE
Performance upgrade: useReducer everywhere and memoize Line components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -106,7 +106,9 @@ const AppContent: React.FC<{}> = (): JSX.Element => {
         DemoModePath.isPlayMode(location.pathname) ||
         location.pathname === guitarDemoPath.URL();
 
-    const withRegularAppLayout = (child: React.ReactElement) => {
+    const withRegularAppLayout = (
+        child: React.ReactElement | React.ReactElement[]
+    ) => {
         return (
             <>
                 {!isFullScreen && (
@@ -149,7 +151,7 @@ const AppContent: React.FC<{}> = (): JSX.Element => {
                 {withRegularAppLayout(<Demo />)}
             </Route>
 
-            {TutorialSwitches()}
+            {TutorialSwitches(withRegularAppLayout)}
             <Route key={aboutPath.URL()} path={aboutPath.URL()} exact>
                 {withRegularAppLayout(<About />)}
             </Route>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import {
 } from "./common/paths";
 import About from "./components/about/About";
 import Demo from "./components/Demo";
+import DragAndDrop from "./components/edit/DragAndDrop";
 import GlobalKeyListenerProvider from "./components/GlobalKeyListener";
 import GuitarDemo from "./components/guitar/GuitarDemo";
 import SideMenu from "./components/SideMenu";
@@ -172,9 +173,11 @@ function App() {
                 />
                 <SnackbarProvider>
                     <HashRouter>
-                        <GlobalKeyListenerProvider>
-                            <AppContent />
-                        </GlobalKeyListenerProvider>
+                        <DragAndDrop>
+                            <GlobalKeyListenerProvider>
+                                <AppContent />
+                            </GlobalKeyListenerProvider>
+                        </DragAndDrop>
                     </HashRouter>
                 </SnackbarProvider>
             </ThemeProvider>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,8 +37,10 @@ import SongRouter from "./components/SongRouter";
 import { TutorialSwitches } from "./components/Tutorial";
 import { User, UserContext } from "./components/user/userContext";
 import Version from "./components/Version";
-import { withSongContext } from "./components/WithSongContext";
-import { withCloud } from "./components/WithCloud";
+import {
+    withCloudSaveSongContext,
+    withSongContext,
+} from "./components/WithSongContext";
 import GlobalKeyListenerProvider from "./components/GlobalKeyListener";
 import GuitarDemo from "./components/guitar/GuitarDemo";
 
@@ -92,7 +94,7 @@ const AppLayout = withStyles({
     },
 })(Grid);
 
-const MainSong = withSongContext(withCloud(SongRouter));
+const MainSong = withCloudSaveSongContext(SongRouter);
 
 const AppContent: React.FC<{}> = (): JSX.Element => {
     const [user, setUser] = useState<User | null>(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,8 +18,6 @@ import {
 } from "react-router-dom";
 import Background from "./assets/img/symphony.png";
 import { ChordSong } from "./common/ChordModel/ChordSong";
-import About from "./components/about/About";
-import Demo from "./components/Demo";
 import {
     aboutPath,
     DemoModePath,
@@ -30,19 +28,17 @@ import {
     SongIDModePath,
     songPath,
 } from "./common/paths";
-
+import About from "./components/about/About";
+import Demo from "./components/Demo";
+import GlobalKeyListenerProvider from "./components/GlobalKeyListener";
+import GuitarDemo from "./components/guitar/GuitarDemo";
 import SideMenu from "./components/SideMenu";
 import SongFetcher from "./components/SongFetcher";
 import SongRouter from "./components/SongRouter";
 import { TutorialSwitches } from "./components/Tutorial";
 import { User, UserContext } from "./components/user/userContext";
 import Version from "./components/Version";
-import {
-    withCloudSaveSongContext,
-    withSongContext,
-} from "./components/WithSongContext";
-import GlobalKeyListenerProvider from "./components/GlobalKeyListener";
-import GuitarDemo from "./components/guitar/GuitarDemo";
+import { withCloudSaveSongContext } from "./components/WithSongContext";
 
 const createTheme = (): Theme => {
     const lightBlue: PaletteColorOptions = {

--- a/src/components/SongRouter.tsx
+++ b/src/components/SongRouter.tsx
@@ -10,7 +10,6 @@ import { ChordSongAction } from "./reducer/reducer";
 interface SongRouterProps {
     path: SongIDPath | DemoPath;
     song: ChordSong;
-    onSongChanged?: (song: ChordSong) => void;
     songDispatch: React.Dispatch<ChordSongAction>;
 }
 
@@ -38,7 +37,6 @@ const SongRouter: MultiFC<SongRouterProps> = (
             <ChordPaper
                 song={props.song}
                 songDispatch={props.songDispatch}
-                onSongChanged={props.onSongChanged}
                 onPlay={switchToPlay}
             />
         </Route>,

--- a/src/components/SongRouter.tsx
+++ b/src/components/SongRouter.tsx
@@ -5,11 +5,13 @@ import { MultiFC, transformToFC } from "../common/FunctionalComponent";
 import ChordPaper from "./edit/ChordPaper";
 import { DemoPath, SongIDPath } from "../common/paths";
 import Play from "./play/Play";
+import { ChordSongAction } from "./reducer/reducer";
 
 interface SongRouterProps {
     path: SongIDPath | DemoPath;
     song: ChordSong;
     onSongChanged?: (song: ChordSong) => void;
+    songDispatch: React.Dispatch<ChordSongAction>;
 }
 
 const SongRouter: MultiFC<SongRouterProps> = (

--- a/src/components/SongRouter.tsx
+++ b/src/components/SongRouter.tsx
@@ -37,6 +37,7 @@ const SongRouter: MultiFC<SongRouterProps> = (
         <Route key={editPath.URL()} path={editPath.URL()}>
             <ChordPaper
                 song={props.song}
+                songDispatch={props.songDispatch}
                 onSongChanged={props.onSongChanged}
                 onPlay={switchToPlay}
             />

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -157,10 +157,14 @@ interface TutorialProps {
     route: string;
 }
 
-export const TutorialSwitches = (): React.ReactElement[] => {
+type WrapperFn = (child: React.ReactElement) => React.ReactElement;
+
+export const TutorialSwitches = (
+    wrapperFn: WrapperFn
+): React.ReactElement[] => {
     return allExercises.map((exerciseEntry: ExerciseEntry) => (
         <Route key={exerciseEntry.route} exact path={exerciseEntry.route}>
-            <Tutorial route={exerciseEntry.route} />
+            {wrapperFn(<Tutorial route={exerciseEntry.route} />)}
         </Route>
     ));
 };
@@ -172,9 +176,8 @@ const Tutorial: React.FC<TutorialProps> = (
         return entry.route === props.route;
     };
 
-    const exerciseEntry: ExerciseEntry | undefined = allExercises.find(
-        matchEntry
-    );
+    const exerciseEntry: ExerciseEntry | undefined =
+        allExercises.find(matchEntry);
 
     if (exerciseEntry === undefined) {
         return <ErrorPage />;

--- a/src/components/WithCloud.tsx
+++ b/src/components/WithCloud.tsx
@@ -65,6 +65,7 @@ export const useCloud = (): [() => void, (song: ChordSong) => JSX.Element] => {
                     return;
                 }
 
+                //TODO: how to update song before dispatch is finished? hook?
                 newSong.lastSavedAt = deserializeResult.right.lastSavedAt;
             };
 

--- a/src/components/WithCloud.tsx
+++ b/src/components/WithCloud.tsx
@@ -69,7 +69,6 @@ export const useCloud = (): [() => void, (song: ChordSong) => JSX.Element] => {
             };
 
             const saveIfChanged = async (newSong: ChordSong) => {
-                // debugger;
                 if (user === null) {
                     return;
                 }
@@ -90,7 +89,7 @@ export const useCloud = (): [() => void, (song: ChordSong) => JSX.Element] => {
                 saveInterval
             );
             return () => clearInterval(interval);
-        }, [song, user, enqueueSnackbar, showError, dirtyRef, shouldSave]);
+        }, [song, user, enqueueSnackbar, showError, shouldSave]);
 
         useEffect(() => {
             const unloadMessageFn = (event: Event) => {

--- a/src/components/WithSongContext.tsx
+++ b/src/components/WithSongContext.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from "react";
+import React from "react";
 import { ChordSong } from "../common/ChordModel/ChordSong";
 import { ChordSongAction, useChordSongReducer } from "./reducer/reducer";
 import { useCloud } from "./WithCloud";
@@ -6,21 +6,13 @@ import { useCloud } from "./WithCloud";
 interface OriginalComponentProps {
     song: ChordSong;
     songDispatch: React.Dispatch<ChordSongAction>;
-    onSongChanged?: (song: ChordSong) => void;
 }
 
 export const withSongContext = <P extends OriginalComponentProps>(
     OriginalComponent: React.FC<P>
-): React.FC<Omit<P, "songDispatch" | "onSongChanged">> => {
-    return (props: Omit<P, "songDispatch" | "onSongChanged">): JSX.Element => {
+): React.FC<Omit<P, "songDispatch">> => {
+    return (props: Omit<P, "songDispatch">): JSX.Element => {
         const [song, songDispatch] = useChordSongReducer(props.song);
-
-        const handleSongChanged = useCallback(
-            (song: ChordSong) => {
-                songDispatch({ type: "set-song", song: song });
-            },
-            [songDispatch]
-        );
 
         const { song: throwawaySong, ...propsWithoutInitialSong } = props;
 
@@ -29,7 +21,6 @@ export const withSongContext = <P extends OriginalComponentProps>(
             ...propsWithoutInitialSong,
             song: song,
             songDispatch: songDispatch,
-            onSongChanged: handleSongChanged,
         } as P;
 
         return <OriginalComponent {...originalComponentProps} />;
@@ -47,13 +38,6 @@ export const withCloudSaveSongContext = <P extends OriginalComponentProps>(
         );
         const unsavedPrompt = useSave(song);
 
-        const handleSongChanged = useCallback(
-            (song: ChordSong) => {
-                songDispatch({ type: "set-song", song: song });
-            },
-            [songDispatch]
-        );
-
         const { song: throwawaySong, ...propsWithoutInitialSong } = props;
 
         // https://github.com/microsoft/TypeScript/issues/35858
@@ -61,7 +45,6 @@ export const withCloudSaveSongContext = <P extends OriginalComponentProps>(
             ...propsWithoutInitialSong,
             song: song,
             songDispatch: songDispatch,
-            onSongChanged: handleSongChanged,
         } as P;
 
         return (

--- a/src/components/WithSongContext.tsx
+++ b/src/components/WithSongContext.tsx
@@ -1,21 +1,26 @@
 import React, { useState } from "react";
+import { useCallback } from "react";
+import { useReducer } from "react";
 import { ChordSong } from "../common/ChordModel/ChordSong";
+import { useChordSongReducer } from "./reducer/reducer";
 
 interface SongProps {
     song: ChordSong;
-    onSongChanged?: (song: ChordSong) => void;
+    onSongChanged: (song: ChordSong) => void;
 }
 
 export const withSongContext = <P extends SongProps>(
     OriginalComponent: React.FC<P>
 ): React.FC<P> => {
     return (props: P): JSX.Element => {
-        const [song, setSong] = useState<ChordSong>(props.song);
+        const [song, dispatch] = useChordSongReducer(
+            props.song,
+            props.onSongChanged
+        );
 
-        const handleSongChanged = (song: ChordSong) => {
-            setSong(song.clone());
-            props.onSongChanged?.(song);
-        };
+        const handleSongChanged = useCallback((song: ChordSong) => {
+            dispatch({ type: "set-state", song: song });
+        }, []);
 
         const { song: throwawaySong, ...propsWithoutInitialSong } = props;
 

--- a/src/components/WithSongContext.tsx
+++ b/src/components/WithSongContext.tsx
@@ -17,7 +17,7 @@ export const withSongContext = <P extends OriginalComponentProps>(
 
         const handleSongChanged = useCallback(
             (song: ChordSong) => {
-                songDispatch({ type: "set-state", song: song });
+                songDispatch({ type: "set-song", song: song });
             },
             [songDispatch]
         );
@@ -49,7 +49,7 @@ export const withCloudSaveSongContext = <P extends OriginalComponentProps>(
 
         const handleSongChanged = useCallback(
             (song: ChordSong) => {
-                songDispatch({ type: "set-state", song: song });
+                songDispatch({ type: "set-song", song: song });
             },
             [songDispatch]
         );

--- a/src/components/WithSongContext.tsx
+++ b/src/components/WithSongContext.tsx
@@ -2,24 +2,23 @@ import React, { useState } from "react";
 import { useCallback } from "react";
 import { useReducer } from "react";
 import { ChordSong } from "../common/ChordModel/ChordSong";
-import { useChordSongReducer } from "./reducer/reducer";
+import { ChordSongAction, useChordSongReducer } from "./reducer/reducer";
+import { useCloud } from "./WithCloud";
 
-interface SongProps {
+interface OriginalComponentProps {
     song: ChordSong;
-    onSongChanged: (song: ChordSong) => void;
+    songDispatch: React.Dispatch<ChordSongAction>;
+    onSongChanged?: (song: ChordSong) => void;
 }
 
-export const withSongContext = <P extends SongProps>(
+export const withSongContext = <P extends OriginalComponentProps>(
     OriginalComponent: React.FC<P>
-): React.FC<P> => {
-    return (props: P): JSX.Element => {
-        const [song, dispatch] = useChordSongReducer(
-            props.song,
-            props.onSongChanged
-        );
+): React.FC<Omit<P, "songDispatch" | "onSongChanged">> => {
+    return (props: Omit<P, "songDispatch" | "onSongChanged">): JSX.Element => {
+        const [song, songDispatch] = useChordSongReducer(props.song);
 
         const handleSongChanged = useCallback((song: ChordSong) => {
-            dispatch({ type: "set-state", song: song });
+            songDispatch({ type: "set-state", song: song });
         }, []);
 
         const { song: throwawaySong, ...propsWithoutInitialSong } = props;
@@ -28,9 +27,44 @@ export const withSongContext = <P extends SongProps>(
         const originalComponentProps = {
             ...propsWithoutInitialSong,
             song: song,
+            songDispatch: songDispatch,
             onSongChanged: handleSongChanged,
         } as P;
 
         return <OriginalComponent {...originalComponentProps} />;
+    };
+};
+
+export const withCloudSaveSongContext = <P extends OriginalComponentProps>(
+    OriginalComponent: React.FC<P>
+): React.FC<Omit<P, "songDispatch">> => {
+    return (props: Omit<P, "songDispatch">): JSX.Element => {
+        const [onSongChange, useSave] = useCloud();
+        const [song, songDispatch] = useChordSongReducer(
+            props.song,
+            onSongChange
+        );
+        const unsavedPrompt = useSave(song);
+
+        const handleSongChanged = useCallback((song: ChordSong) => {
+            songDispatch({ type: "set-state", song: song });
+        }, []);
+
+        const { song: throwawaySong, ...propsWithoutInitialSong } = props;
+
+        // https://github.com/microsoft/TypeScript/issues/35858
+        const originalComponentProps = {
+            ...propsWithoutInitialSong,
+            song: song,
+            songDispatch: songDispatch,
+            onSongChanged: handleSongChanged,
+        } as P;
+
+        return (
+            <>
+                {unsavedPrompt}
+                <OriginalComponent {...originalComponentProps} />
+            </>
+        );
     };
 };

--- a/src/components/WithSongContext.tsx
+++ b/src/components/WithSongContext.tsx
@@ -1,6 +1,4 @@
-import React, { useState } from "react";
-import { useCallback } from "react";
-import { useReducer } from "react";
+import React, { useCallback } from "react";
 import { ChordSong } from "../common/ChordModel/ChordSong";
 import { ChordSongAction, useChordSongReducer } from "./reducer/reducer";
 import { useCloud } from "./WithCloud";
@@ -17,9 +15,12 @@ export const withSongContext = <P extends OriginalComponentProps>(
     return (props: Omit<P, "songDispatch" | "onSongChanged">): JSX.Element => {
         const [song, songDispatch] = useChordSongReducer(props.song);
 
-        const handleSongChanged = useCallback((song: ChordSong) => {
-            songDispatch({ type: "set-state", song: song });
-        }, []);
+        const handleSongChanged = useCallback(
+            (song: ChordSong) => {
+                songDispatch({ type: "set-state", song: song });
+            },
+            [songDispatch]
+        );
 
         const { song: throwawaySong, ...propsWithoutInitialSong } = props;
 
@@ -46,9 +47,12 @@ export const withCloudSaveSongContext = <P extends OriginalComponentProps>(
         );
         const unsavedPrompt = useSave(song);
 
-        const handleSongChanged = useCallback((song: ChordSong) => {
-            songDispatch({ type: "set-state", song: song });
-        }, []);
+        const handleSongChanged = useCallback(
+            (song: ChordSong) => {
+                songDispatch({ type: "set-state", song: song });
+            },
+            [songDispatch]
+        );
 
         const { song: throwawaySong, ...propsWithoutInitialSong } = props;
 

--- a/src/components/WithSongContext.tsx
+++ b/src/components/WithSongContext.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { ChordSong } from "../common/ChordModel/ChordSong";
 import { ChordSongAction, useChordSongReducer } from "./reducer/reducer";
-import { useCloud } from "./WithCloud";
+import { useCloud } from "./useCloud";
 
 interface OriginalComponentProps {
     song: ChordSong;
@@ -36,7 +36,7 @@ export const withCloudSaveSongContext = <P extends OriginalComponentProps>(
             props.song,
             onSongChange
         );
-        const unsavedPrompt = useSave(song);
+        const unsavedPrompt = useSave(song, songDispatch);
 
         const { song: throwawaySong, ...propsWithoutInitialSong } = props;
 

--- a/src/components/edit/BatchDelete.ts
+++ b/src/components/edit/BatchDelete.ts
@@ -1,27 +1,23 @@
 import { ChordLine } from "../../common/ChordModel/ChordLine";
-import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { IDable } from "../../common/ChordModel/Collection";
 import { getSelectedLineIDs } from "./LineSelection";
 
-export const useBatchLineDelete = (song: ChordSong) => {
-    return (event: React.KeyboardEvent<HTMLDivElement>): boolean => {
-        if (event.key !== "Backspace") {
-            return false;
-        }
+export const handleBatchLineDelete = (
+    event: React.KeyboardEvent<HTMLDivElement>
+): false | IDable<ChordLine>[] => {
+    if (event.key !== "Backspace") {
+        return false;
+    }
 
-        const lineIDs: string[] = getSelectedLineIDs();
-        if (lineIDs.length === 0) {
-            return false;
-        }
+    const lineIDs: string[] = getSelectedLineIDs();
+    if (lineIDs.length === 0) {
+        return false;
+    }
 
-        const lineIDables: IDable<ChordLine>[] = lineIDs.map((id: string) => ({
-            type: "ChordLine",
-            id: id,
-        }));
+    event.preventDefault();
 
-        song.removeMultiple(lineIDables);
-        event.preventDefault();
-
-        return true;
-    };
+    return lineIDs.map((id: string) => ({
+        type: "ChordLine",
+        id: id,
+    }));
 };

--- a/src/components/edit/Block.tsx
+++ b/src/components/edit/Block.tsx
@@ -9,6 +9,7 @@ import { Lyric } from "../../common/ChordModel/Lyric";
 import { DataTestID } from "../../common/DataTestID";
 import { inflatingWhitespace } from "../../common/Whitespace";
 import { lyricTypographyVariant } from "../display/Lyric";
+import { ChordSongAction } from "../reducer/reducer";
 import ChordDroppable from "./ChordDroppable";
 import DraggableChordSymbol from "./DraggableChordSymbol";
 import {
@@ -67,13 +68,8 @@ const useNormalTokenStyle = {
 
 export interface BlockProps extends DataTestID {
     chordBlock: ChordBlock;
-    onChordDragAndDrop?: (
-        destinationBlockID: IDable<ChordBlock>,
-        splitIndex: number,
-        newChord: string,
-        sourceBlockID: IDable<ChordBlock>,
-        copyAction: boolean
-    ) => void;
+    songDispatch: React.Dispatch<ChordSongAction>;
+
     onChordChange?: (id: IDable<ChordBlock>, newChord: string) => void;
     onBlockSplit?: (id: IDable<ChordBlock>, splitIndex: number) => void;
 }
@@ -128,13 +124,14 @@ const Block: React.FC<BlockProps> = (props: BlockProps): JSX.Element => {
             sourceBlockID: IDable<ChordBlock>,
             copyAction: boolean
         ) => {
-            props.onChordDragAndDrop?.(
-                props.chordBlock,
-                tokenIndex,
-                newChord,
-                sourceBlockID,
-                copyAction
-            );
+            props.songDispatch({
+                type: "drag-and-drop-chord",
+                sourceBlockID: sourceBlockID,
+                newChord: newChord,
+                destinationBlockID: props.chordBlock,
+                splitIndex: tokenIndex,
+                copyAction: copyAction,
+            });
         };
     };
 

--- a/src/components/edit/ChordPaper.tsx
+++ b/src/components/edit/ChordPaper.tsx
@@ -32,7 +32,6 @@ const useWhiteStyle = makeStyles({
 
 interface ChordPaperProps {
     song: ChordSong;
-    onSongChanged?: (song: ChordSong) => void;
     songDispatch: React.Dispatch<ChordSongAction>;
     onPlay?: PlainFn;
 }
@@ -41,10 +40,6 @@ const ChordPaper: React.FC<ChordPaperProps> = (
     props: ChordPaperProps
 ): JSX.Element => {
     const whiteStyle = useWhiteStyle();
-
-    const songChangeHandler = (song: ChordSong) => {
-        props.onSongChanged?.(song);
-    };
 
     const trackPlayer: React.ReactNode = (() => {
         if (props.song.isUnsaved()) {
@@ -88,7 +83,6 @@ const ChordPaper: React.FC<ChordPaperProps> = (
                 <ChordPaperBody
                     song={props.song}
                     songDispatch={props.songDispatch}
-                    onSongChanged={songChangeHandler}
                 />
                 <ChordPaperMenu
                     song={props.song}

--- a/src/components/edit/ChordPaper.tsx
+++ b/src/components/edit/ChordPaper.tsx
@@ -5,6 +5,7 @@ import { Helmet } from "react-helmet-async";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { PlainFn } from "../../common/PlainFn";
 import PlayerTimeProvider from "../PlayerTimeContext";
+import { ChordSongAction } from "../reducer/reducer";
 import JamStation from "../track_player/JamStation";
 import TrackListProvider, {
     TrackListChangeHandler,
@@ -32,6 +33,7 @@ const useWhiteStyle = makeStyles({
 interface ChordPaperProps {
     song: ChordSong;
     onSongChanged?: (song: ChordSong) => void;
+    songDispatch: React.Dispatch<ChordSongAction>;
     onPlay?: PlainFn;
 }
 
@@ -81,15 +83,16 @@ const ChordPaper: React.FC<ChordPaperProps> = (
                 <Header
                     data-testid={"Header"}
                     song={props.song}
-                    onSongChanged={songChangeHandler}
+                    songDispatch={props.songDispatch}
                 />
                 <ChordPaperBody
                     song={props.song}
+                    songDispatch={props.songDispatch}
                     onSongChanged={songChangeHandler}
                 />
                 <ChordPaperMenu
                     song={props.song}
-                    onSongChanged={songChangeHandler}
+                    songDispatch={props.songDispatch}
                     onPlay={props.onPlay}
                 />
                 {trackPlayer}

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -86,17 +86,6 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
         return true;
     };
 
-    const mergeWithPreviousLine = (id: IDable<ChordLine>): boolean => {
-        const didMerge = props.song.mergeLineWithPrevious(id);
-
-        if (didMerge) {
-            notifySongChanged();
-            return true;
-        }
-
-        return false;
-    };
-
     const notifySongChanged = () => {
         props.onSongChanged?.(props.song);
     };
@@ -144,7 +133,6 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
                         data-lineid={line.id}
                         onChangeLine={handleChangeLine}
                         onJSONPaste={handleJSONPaste}
-                        onMergeWithPreviousLine={mergeWithPreviousLine}
                         onChordDragAndDrop={handleChordDND}
                         data-testid={`Line-${index}`}
                     />,

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -121,23 +121,21 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
         : uninteractiveStyle.root;
 
     return (
-        <DragAndDrop>
-            <InteractionContext.Provider value={interactionContextValue}>
-                <Paper
-                    onKeyDown={allowInteraction ? handleKeyDown : undefined}
-                    onCopy={allowInteraction ? handleCopy : undefined}
-                    className={paperClassName}
-                    elevation={0}
-                    tabIndex={0}
-                >
-                    <Grid container justify="center">
-                        <Grid item xs={10}>
-                            {lines()}
-                        </Grid>
+        <InteractionContext.Provider value={interactionContextValue}>
+            <Paper
+                onKeyDown={allowInteraction ? handleKeyDown : undefined}
+                onCopy={allowInteraction ? handleCopy : undefined}
+                className={paperClassName}
+                elevation={0}
+                tabIndex={0}
+            >
+                <Grid container justify="center">
+                    <Grid item xs={10}>
+                        {lines()}
                     </Grid>
-                </Paper>
-            </InteractionContext.Provider>
-        </DragAndDrop>
+                </Grid>
+            </Paper>
+        </InteractionContext.Provider>
     );
 };
 

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -73,39 +73,33 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
     };
 
     const lines = () => {
-        const lines = props.song.chordLines.flatMap(
-            (line: ChordLine, index: number) => {
-                return [
-                    <Line
-                        key={line.id}
-                        chordLine={line}
-                        jsonHackUntilWeHaveImmutableDataStructures={JSON.stringify(
-                            line
-                        )}
-                        songDispatch={songDispatch}
-                        data-lineid={line.id}
-                        data-testid={line.id}
-                        // TODO
-                        // data-testid={`Line-${index}`}
-                    />,
-                    <NewLine
-                        key={"NewLine-" + line.id}
-                        lineID={line}
-                        songDispatch={songDispatch}
-                        data-testid={line.id}
-                        // TODO
-                        // data-testid={`NewLine-${index}`}
-                    />,
-                ];
-            }
-        );
+        const lines = props.song.chordLines.flatMap((line: ChordLine) => {
+            return [
+                <Line
+                    key={line.id}
+                    chordLine={line}
+                    jsonHackUntilWeHaveImmutableDataStructures={JSON.stringify(
+                        line
+                    )}
+                    songDispatch={songDispatch}
+                    data-lineid={line.id}
+                    data-testid="Line"
+                />,
+                <NewLine
+                    key={"NewLine-" + line.id}
+                    lineID={line}
+                    songDispatch={songDispatch}
+                    data-testid="NewLine"
+                />,
+            ];
+        });
 
         const firstNewLine = (
             <NewLine
                 key={"NewLine-Top"}
                 lineID="beginning"
                 songDispatch={songDispatch}
-                data-testid={"NewLine-Top"}
+                data-testid="NewLine-Top"
             />
         );
         lines.splice(0, 0, firstNewLine);

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -4,7 +4,7 @@ import {
     Paper as UnstyledPaper,
     withStyles,
 } from "@material-ui/core";
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { ChordSongAction } from "../reducer/reducer";
@@ -41,18 +41,21 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
     const handleBatchLineDelete = useBatchLineDelete(props.song);
     const songDispatch = props.songDispatch;
 
-    const interactionContextValue: InteractionSetter = {
-        startInteraction: () => {
-            setTimeout(() => {
-                setInteracting(true);
-            });
-        },
-        endInteraction: () => {
-            setTimeout(() => {
-                setInteracting(false);
-            });
-        },
-    };
+    const interactionContextValue: InteractionSetter = useMemo(
+        () => ({
+            startInteraction: () => {
+                setTimeout(() => {
+                    setInteracting(true);
+                });
+            },
+            endInteraction: () => {
+                setTimeout(() => {
+                    setInteracting(false);
+                });
+            },
+        }),
+        []
+    );
 
     const uninteractiveStyle = useUninteractiveStyle();
 
@@ -77,6 +80,9 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
                     <Line
                         key={line.id}
                         chordLine={line}
+                        jsonHackUntilWeHaveImmutableDataStructures={JSON.stringify(
+                            line
+                        )}
                         songDispatch={songDispatch}
                         data-lineid={line.id}
                         data-testid={line.id}

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -5,13 +5,11 @@ import {
     withStyles,
 } from "@material-ui/core";
 import React, { useState } from "react";
-import { ChordBlock } from "../../common/ChordModel/ChordBlock";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
-import { IDable } from "../../common/ChordModel/Collection";
 import { ChordSongAction } from "../reducer/reducer";
 import { useBatchLineDelete } from "./BatchDelete";
-import { useLineCopyHandler, useLinePasteHandler } from "./CopyAndPaste";
+import { useLineCopyHandler } from "./CopyAndPaste";
 import DragAndDrop from "./DragAndDrop";
 import { InteractionContext, InteractionSetter } from "./InteractionContext";
 import Line from "./Line";
@@ -40,7 +38,6 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
 ): React.ReactElement => {
     const [interacting, setInteracting] = useState(false);
     const handleCopy = useLineCopyHandler(props.song);
-    const handleLinePaste = useLinePasteHandler(props.song);
     const handleBatchLineDelete = useBatchLineDelete(props.song);
     const songDispatch = props.songDispatch;
 
@@ -59,23 +56,6 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
 
     const uninteractiveStyle = useUninteractiveStyle();
 
-    const handleChangeLine = (id: IDable<ChordLine>) => {
-        notifySongChanged();
-    };
-
-    const handleJSONPaste = (
-        id: IDable<ChordLine>,
-        jsonStr: string
-    ): boolean => {
-        const handled = handleLinePaste(id, jsonStr);
-        if (!handled) {
-            return false;
-        }
-
-        notifySongChanged();
-        return true;
-    };
-
     const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
         const handled = handleBatchLineDelete(event);
         if (!handled) {
@@ -90,38 +70,6 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
         props.onSongChanged?.(props.song);
     };
 
-    const handleChordDND = (
-        destinationBlockID: IDable<ChordBlock>,
-        splitIndex: number,
-        newChord: string,
-        sourceBlockID: IDable<ChordBlock>,
-        copyAction: boolean
-    ) => {
-        const [sourceLine, sourceBlock] =
-            props.song.findLineAndBlock(sourceBlockID);
-
-        const moveAction = !copyAction;
-        if (moveAction) {
-            // clearing the source block first allows handling of when the chord
-            // is dropped onto another token in the same block without special cases
-            sourceBlock.chord = "";
-        }
-
-        const [destinationLine, destinationBlock] =
-            props.song.findLineAndBlock(destinationBlockID);
-
-        if (splitIndex !== 0) {
-            destinationLine.splitBlock(destinationBlockID, splitIndex);
-        }
-
-        destinationBlock.chord = newChord;
-
-        sourceLine.normalizeBlocks();
-        destinationLine.normalizeBlocks();
-
-        notifySongChanged();
-    };
-
     const lines = () => {
         const lines = props.song.chordLines.flatMap(
             (line: ChordLine, index: number) => {
@@ -131,16 +79,17 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
                         chordLine={line}
                         songDispatch={songDispatch}
                         data-lineid={line.id}
-                        onChangeLine={handleChangeLine}
-                        onJSONPaste={handleJSONPaste}
-                        onChordDragAndDrop={handleChordDND}
-                        data-testid={`Line-${index}`}
+                        data-testid={line.id}
+                        // TODO
+                        // data-testid={`Line-${index}`}
                     />,
                     <NewLine
                         key={"NewLine-" + line.id}
                         lineID={line}
                         songDispatch={songDispatch}
-                        data-testid={`NewLine-${index}`}
+                        data-testid={line.id}
+                        // TODO
+                        // data-testid={`NewLine-${index}`}
                     />,
                 ];
             }

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -10,7 +10,6 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { ChordSongAction } from "../reducer/reducer";
 import { useBatchLineDelete } from "./BatchDelete";
 import { useLineCopyHandler } from "./CopyAndPaste";
-import DragAndDrop from "./DragAndDrop";
 import { InteractionContext, InteractionSetter } from "./InteractionContext";
 import Line from "./Line";
 import NewLine from "./NewLine";

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -8,7 +8,7 @@ import React, { useMemo, useState } from "react";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { ChordSongAction } from "../reducer/reducer";
-import { useBatchLineDelete } from "./BatchDelete";
+import { handleBatchLineDelete } from "./BatchDelete";
 import { useLineCopyHandler } from "./CopyAndPaste";
 import { InteractionContext, InteractionSetter } from "./InteractionContext";
 import Line from "./Line";
@@ -29,7 +29,6 @@ const Paper = withStyles({
 interface ChordPaperBodyProps {
     song: ChordSong;
     songDispatch: React.Dispatch<ChordSongAction>;
-    onSongChanged?: (updatedSong: ChordSong) => void;
 }
 
 const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
@@ -37,7 +36,6 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
 ): React.ReactElement => {
     const [interacting, setInteracting] = useState(false);
     const handleCopy = useLineCopyHandler(props.song);
-    const handleBatchLineDelete = useBatchLineDelete(props.song);
     const songDispatch = props.songDispatch;
 
     const interactionContextValue: InteractionSetter = useMemo(
@@ -58,18 +56,18 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
 
     const uninteractiveStyle = useUninteractiveStyle();
 
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-        const handled = handleBatchLineDelete(event);
-        if (!handled) {
-            return false;
+    const handleKeyDown = (
+        event: React.KeyboardEvent<HTMLDivElement>
+    ): void => {
+        const lineIDs = handleBatchLineDelete(event);
+        if (!lineIDs) {
+            return;
         }
 
-        notifySongChanged();
-        return true;
-    };
-
-    const notifySongChanged = () => {
-        props.onSongChanged?.(props.song);
+        songDispatch({
+            type: "batch-remove-lines",
+            lineIDs: lineIDs,
+        });
     };
 
     const lines = () => {

--- a/src/components/edit/DragAndDrop.tsx
+++ b/src/components/edit/DragAndDrop.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from "react";
+import React, { useMemo, useRef } from "react";
 import { createDndContext, DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 
@@ -57,15 +57,13 @@ export const HTML5BackendWithCTRLKey = (
 const RNDContext = createDndContext(HTML5BackendWithCTRLKey);
 
 interface DragAndDropProps {
-    children: React.ReactElement | null;
+    children: React.ReactElement;
 }
 
-function useDNDProviderElement(props: DragAndDropProps) {
+const DragAndDrop: React.FC<DragAndDropProps> = (
+    props: DragAndDropProps
+): JSX.Element => {
     const manager = useRef(RNDContext);
-
-    if (!props.children) {
-        throw new Error("No children provided to DND wrapper");
-    }
 
     if (manager.current.dragDropManager === undefined) {
         throw new Error("No DND manager found");
@@ -76,13 +74,6 @@ function useDNDProviderElement(props: DragAndDropProps) {
             {props.children}
         </DndProvider>
     );
-}
-
-const DragAndDrop: React.FC<DragAndDropProps> = (
-    props: DragAndDropProps
-): JSX.Element => {
-    const DNDElement = useDNDProviderElement(props);
-    return <React.Fragment>{DNDElement}</React.Fragment>;
 };
 
 export default DragAndDrop;

--- a/src/components/edit/DragAndDrop.tsx
+++ b/src/components/edit/DragAndDrop.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from "react";
+import React, { useRef } from "react";
 import { createDndContext, DndProvider } from "react-dnd";
 import { HTML5Backend } from "react-dnd-html5-backend";
 

--- a/src/components/edit/Header.tsx
+++ b/src/components/edit/Header.tsx
@@ -3,6 +3,7 @@ import { useTheme, withStyles } from "@material-ui/styles";
 import React from "react";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
 import UnstyledLastSavedAt from "../display/LastSavedAt";
+import { ChordSongAction } from "../reducer/reducer";
 import EditableTypography from "./EditableTypography";
 
 const LastSavedAt = withStyles((theme: Theme) => ({
@@ -15,31 +16,22 @@ const LastSavedAt = withStyles((theme: Theme) => ({
 
 interface HeaderProps {
     song: ChordSong;
-    onSongChanged?: (updatedSong: ChordSong) => void;
+    songDispatch: React.Dispatch<ChordSongAction>;
 }
 
 const Header: React.FC<HeaderProps> = (props: HeaderProps): JSX.Element => {
     const theme: Theme = useTheme();
 
-    const notifySongChanged = (): void => {
-        if (props.onSongChanged) {
-            props.onSongChanged(props.song);
-        }
-    };
-
     const updateTitleHandler = (newTitle: string) => {
-        props.song.title = newTitle;
-        notifySongChanged();
+        props.songDispatch({ type: "set-header", title: newTitle });
     };
 
     const updateComposeHandler = (newComposer: string) => {
-        props.song.composedBy = newComposer;
-        notifySongChanged();
+        props.songDispatch({ type: "set-header", composedBy: newComposer });
     };
 
     const updatePerformerHandler = (newPerformer: string) => {
-        props.song.performedBy = newPerformer;
-        notifySongChanged();
+        props.songDispatch({ type: "set-header", performedBy: newPerformer });
     };
 
     const title = (

--- a/src/components/edit/InteractionContext.ts
+++ b/src/components/edit/InteractionContext.ts
@@ -11,9 +11,8 @@ const defaultSetter: InteractionSetter = {
     endInteraction: () => {},
 };
 
-export const InteractionContext = React.createContext<InteractionSetter>(
-    defaultSetter
-);
+export const InteractionContext =
+    React.createContext<InteractionSetter>(defaultSetter);
 
 interface EditingState {
     editing: boolean;

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -38,6 +38,7 @@ const HighlightableBox = withStyles({
 
 interface LineProps extends DataTestID {
     chordLine: ChordLine;
+    jsonHackUntilWeHaveImmutableDataStructures: string;
     songDispatch: React.Dispatch<ChordSongAction>;
     "data-lineid": string;
 }

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -10,6 +10,7 @@ import { IDable } from "../../common/ChordModel/Collection";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { DataTestID } from "../../common/DataTestID";
 import { PlainFn } from "../../common/PlainFn";
+import { ChordSongAction } from "../reducer/reducer";
 import Block, { BlockProps } from "./Block";
 import WithHoverMenu, { MenuItem } from "./WithHoverMenu";
 import WithLyricInput from "./WithLyricInput";
@@ -37,16 +38,11 @@ const HighlightableBox = withStyles({
 
 interface LineProps extends DataTestID {
     chordLine: ChordLine;
+    songDispatch: React.Dispatch<ChordSongAction>;
     "data-lineid": string;
     onChangeLine?: (id: IDable<ChordLine>) => void;
-    onRemoveLine?: (id: IDable<ChordLine>) => void;
-    onLyricOverflow?: (
-        id: IDable<ChordLine>,
-        overflowLyricContent: Lyric[]
-    ) => void;
     onJSONPaste?: (id: IDable<ChordLine>, jsonStr: string) => boolean;
     onMergeWithPreviousLine?: (id: IDable<ChordLine>) => boolean;
-    onSplitLine?: (id: IDable<ChordLine>, splitIndex: number) => boolean;
     onChordDragAndDrop?: BlockProps["onChordDragAndDrop"];
 }
 
@@ -70,13 +66,12 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
 
             setRemoved(true);
 
-            if (props.onRemoveLine) {
-                setTimeout(() => {
-                    if (props.onRemoveLine) {
-                        props.onRemoveLine(props.chordLine);
-                    }
-                }, removalTime);
-            }
+            setTimeout(() => {
+                props.songDispatch({
+                    type: "remove-line",
+                    lineID: props.chordLine,
+                });
+            }, removalTime);
         },
     };
 
@@ -118,11 +113,9 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
     const withLyricInput = (menuItems: MenuItem[]) => (
         <WithLyricInput
             chordLine={props.chordLine}
-            onChangeLine={props.onChangeLine}
+            songDispatch={props.songDispatch}
             onJSONPaste={props.onJSONPaste}
             onMergeWithPreviousLine={props.onMergeWithPreviousLine}
-            onSplitLine={props.onSplitLine}
-            onLyricOverflow={props.onLyricOverflow}
         >
             {(startEdit: PlainFn) => withHoverMenu(startEdit, menuItems)}
         </WithLyricInput>

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -53,7 +53,7 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
         () => ({
             chordChange: (blockID: IDable<ChordBlock>, newChord: string) => {
                 songDispatch({
-                    type: "change-chord",
+                    type: "set-chord",
                     lineID: chordLine,
                     blockID: blockID,
                     newChord: newChord,

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -38,6 +38,7 @@ const HighlightableBox = withStyles({
 
 interface LineProps extends DataTestID {
     chordLine: ChordLine;
+    //TODO
     jsonHackUntilWeHaveImmutableDataStructures: string;
     songDispatch: React.Dispatch<ChordSongAction>;
     "data-lineid": string;

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -42,7 +42,6 @@ interface LineProps extends DataTestID {
     "data-lineid": string;
     onChangeLine?: (id: IDable<ChordLine>) => void;
     onJSONPaste?: (id: IDable<ChordLine>, jsonStr: string) => boolean;
-    onMergeWithPreviousLine?: (id: IDable<ChordLine>) => boolean;
     onChordDragAndDrop?: BlockProps["onChordDragAndDrop"];
 }
 
@@ -115,7 +114,6 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
             chordLine={props.chordLine}
             songDispatch={props.songDispatch}
             onJSONPaste={props.onJSONPaste}
-            onMergeWithPreviousLine={props.onMergeWithPreviousLine}
         >
             {(startEdit: PlainFn) => withHoverMenu(startEdit, menuItems)}
         </WithLyricInput>

--- a/src/components/edit/NewLine.tsx
+++ b/src/components/edit/NewLine.tsx
@@ -8,8 +8,10 @@ import {
 import UnstyledAddCircleOutlineIcon from "@material-ui/icons/AddCircleOutline";
 import { useTheme, withStyles } from "@material-ui/styles";
 import React from "react";
+import { ChordLine } from "../../common/ChordModel/ChordLine";
+import { IDable } from "../../common/ChordModel/Collection";
 import { DataTestID } from "../../common/DataTestID";
-import { PlainFn } from "../../common/PlainFn";
+import { ChordSongAction } from "../reducer/reducer";
 
 const HighlightableGrid = withStyles({
     root: {
@@ -41,15 +43,27 @@ const AddCircleOutlineIcon = withStyles((theme: Theme) => ({
 }))(UnstyledAddCircleOutlineIcon);
 
 interface NewLineProps extends DataTestID {
-    onAdd?: PlainFn;
+    lineID: IDable<ChordLine> | "beginning";
+    songDispatch: React.Dispatch<ChordSongAction>;
 }
 
 const NewLine: React.FC<NewLineProps> = (props: NewLineProps): JSX.Element => {
     const theme: Theme = useTheme();
 
+    const handleAddLine = () => {
+        if (props.lineID === "beginning") {
+            props.songDispatch({ type: "add-line-beginning" });
+        } else {
+            props.songDispatch({
+                type: "add-line-after",
+                lineID: props.lineID,
+            });
+        }
+    };
+
     const hoverMenu = (): React.ReactElement => {
         return (
-            <Button data-testid={"AddButton"} onClick={props.onAdd}>
+            <Button data-testid={"AddButton"} onClick={handleAddLine}>
                 <AddCircleOutlineIcon />
             </Button>
         );
@@ -61,7 +75,7 @@ const NewLine: React.FC<NewLineProps> = (props: NewLineProps): JSX.Element => {
                 container
                 direction="column"
                 justify="center"
-                onClick={props.onAdd}
+                onClick={handleAddLine}
                 data-testid={props["data-testid"]}
                 style={{
                     minHeight: theme.spacing(3),

--- a/src/components/edit/NewLine.tsx
+++ b/src/components/edit/NewLine.tsx
@@ -51,14 +51,10 @@ const NewLine: React.FC<NewLineProps> = (props: NewLineProps): JSX.Element => {
     const theme: Theme = useTheme();
 
     const handleAddLine = () => {
-        if (props.lineID === "beginning") {
-            props.songDispatch({ type: "add-line-beginning" });
-        } else {
-            props.songDispatch({
-                type: "add-line-after",
-                lineID: props.lineID,
-            });
-        }
+        props.songDispatch({
+            type: "add-line",
+            lineID: props.lineID,
+        });
     };
 
     const hoverMenu = (): React.ReactElement => {

--- a/src/components/edit/WithLyricInput.tsx
+++ b/src/components/edit/WithLyricInput.tsx
@@ -56,12 +56,12 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
                 });
                 finishEdit();
             },
-            jsonPaste: (jsonStr: string): boolean => {
+            jsonPaste: (jsonStr: string): [boolean, PlainFn | null] => {
                 const deserializedCopyResult =
                     deserializeCopiedChordLines(jsonStr);
                 // not actually a Chord Paper line payload, don't handle it
                 if (deserializedCopyResult === null) {
-                    return false;
+                    return [false, null];
                 }
 
                 if (isLeft(deserializedCopyResult)) {
@@ -69,16 +69,17 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
                         "Failed to paste copied lines: " +
                         deserializedCopyResult.left.message;
                     enqueueSnackbar(errorMsg, { variant: "error" });
-                    return true;
+                    return [true, null];
                 }
 
-                songDispatch({
-                    type: "batch-insert-lines",
-                    insertLineID: chordLine,
-                    copiedLines: deserializedCopyResult.right,
-                });
+                const insertLines = () =>
+                    songDispatch({
+                        type: "batch-insert-lines",
+                        insertLineID: chordLine,
+                        copiedLines: deserializedCopyResult.right,
+                    });
 
-                return true;
+                return [true, insertLines];
             },
 
             specialBackspace: () => {

--- a/src/components/edit/WithLyricInput.tsx
+++ b/src/components/edit/WithLyricInput.tsx
@@ -23,7 +23,6 @@ interface WithLyricInputProps {
     chordLine: ChordLine;
     songDispatch: React.Dispatch<ChordSongAction>;
     onJSONPaste?: (id: IDable<ChordLine>, jsonStr: string) => boolean;
-    onMergeWithPreviousLine?: (id: IDable<ChordLine>) => boolean;
 }
 
 // this component is inherently quite coupled with Line & friends
@@ -65,20 +64,15 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
 
             return props.onJSONPaste(props.chordLine, jsonStr);
         },
-        specialBackspace: () => {
-            if (props.onMergeWithPreviousLine) {
-                const handledAndStopEditing = props.onMergeWithPreviousLine(
-                    props.chordLine
-                );
-                if (handledAndStopEditing) {
-                    finishEdit();
-                }
-            }
-        },
+        specialBackspace: useCallback(() => {
+            songDispatch({
+                type: "merge-lines",
+                latterLineID: chordLine,
+            });
+            finishEdit();
+        }, [chordLine, songDispatch, finishEdit]),
         specialEnter: useCallback(
             (splitIndex: number) => {
-                console.log("special enter");
-
                 songDispatch({
                     type: "split-line",
                     lineID: chordLine,

--- a/src/components/edit/WithLyricInput.tsx
+++ b/src/components/edit/WithLyricInput.tsx
@@ -1,7 +1,7 @@
 import { Box, Theme, withStyles } from "@material-ui/core";
 import { isLeft } from "fp-ts/lib/Either";
 import { useSnackbar } from "notistack";
-import React, { useCallback } from "react";
+import React, { useMemo } from "react";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { PlainFn } from "../../common/PlainFn";
@@ -35,9 +35,9 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
     const { songDispatch, chordLine } = props;
     const { enqueueSnackbar } = useSnackbar();
 
-    const handlers = {
-        lyricEdit: useCallback(
-            (newLyric: Lyric) => {
+    const handlers = useMemo(
+        () => ({
+            lyricEdit: (newLyric: Lyric) => {
                 finishEdit();
 
                 songDispatch({
@@ -47,10 +47,8 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
                     newLyric: newLyric,
                 });
             },
-            [chordLine, songDispatch, finishEdit]
-        ),
-        lyricPasteOverflow: useCallback(
-            (overflowContent: Lyric[]) => {
+
+            lyricPasteOverflow: (overflowContent: Lyric[]) => {
                 songDispatch({
                     type: "insert-overflow-lyrics",
                     insertionLineID: chordLine,
@@ -58,10 +56,7 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
                 });
                 finishEdit();
             },
-            [chordLine, songDispatch, finishEdit]
-        ),
-        jsonPaste: useCallback(
-            (jsonStr: string): boolean => {
+            jsonPaste: (jsonStr: string): boolean => {
                 const deserializedCopyResult =
                     deserializeCopiedChordLines(jsonStr);
                 // not actually a Chord Paper line payload, don't handle it
@@ -85,17 +80,15 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
 
                 return true;
             },
-            [chordLine, songDispatch, enqueueSnackbar]
-        ),
-        specialBackspace: useCallback(() => {
-            songDispatch({
-                type: "merge-lines",
-                latterLineID: chordLine,
-            });
-            finishEdit();
-        }, [chordLine, songDispatch, finishEdit]),
-        specialEnter: useCallback(
-            (splitIndex: number) => {
+
+            specialBackspace: () => {
+                songDispatch({
+                    type: "merge-lines",
+                    latterLineID: chordLine,
+                });
+                finishEdit();
+            },
+            specialEnter: (splitIndex: number) => {
                 songDispatch({
                     type: "split-line",
                     lineID: chordLine,
@@ -104,9 +97,9 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
 
                 finishEdit();
             },
-            [chordLine, songDispatch, finishEdit]
-        ),
-    };
+        }),
+        [chordLine, songDispatch, finishEdit, enqueueSnackbar]
+    );
 
     const lineElement: React.ReactElement = props.children(startEdit);
 

--- a/src/components/edit/WithLyricInput.tsx
+++ b/src/components/edit/WithLyricInput.tsx
@@ -73,7 +73,7 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
                 }
 
                 songDispatch({
-                    type: "insert-lines",
+                    type: "batch-insert-lines",
                     insertLineID: chordLine,
                     copiedLines: deserializedCopyResult.right,
                 });

--- a/src/components/edit/WithSection.tsx
+++ b/src/components/edit/WithSection.tsx
@@ -51,7 +51,7 @@ const WithSection: React.FC<WithSectionProps> = (
     const handleLabelChange = useCallback(
         (newValue: string) => {
             songDispatch({
-                type: "set-section-label",
+                type: "set-section",
                 lineID: chordLine,
                 label: newValue,
             });
@@ -62,7 +62,7 @@ const WithSection: React.FC<WithSectionProps> = (
     const handleTimeChange = useCallback(
         (newValue: number | null) => {
             songDispatch({
-                type: "set-section-time",
+                type: "set-section",
                 lineID: chordLine,
                 time: newValue,
             });

--- a/src/components/edit/WithSection.tsx
+++ b/src/components/edit/WithSection.tsx
@@ -115,4 +115,4 @@ const WithSection: React.FC<WithSectionProps> = (
     );
 };
 
-export default React.memo(WithSection);
+export default WithSection;

--- a/src/components/edit/WithSection.tsx
+++ b/src/components/edit/WithSection.tsx
@@ -1,14 +1,14 @@
 import { Box, Theme, Tooltip as UnstyledTooltip } from "@material-ui/core";
 import { withStyles } from "@material-ui/styles";
-import React from "react";
+import React, { useCallback } from "react";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
-import { IDable } from "../../common/ChordModel/Collection";
 import { DataTestID } from "../../common/DataTestID";
 import { PlainFn } from "../../common/PlainFn";
 import {
     sectionLabelStyle,
     sectionTypographyVariant,
 } from "../display/SectionLabel";
+import { ChordSongAction } from "../reducer/reducer";
 import UnstyledEditableTypography, { EditControl } from "./EditableTypography";
 import { useEditingState } from "./InteractionContext";
 import TimeInput from "./TimeInput";
@@ -31,8 +31,8 @@ export interface MenuItem extends DataTestID {
 
 export interface WithSectionProps {
     chordLine: ChordLine;
+    songDispatch: React.Dispatch<ChordSongAction>;
     children: (editLabel: PlainFn) => React.ReactElement;
-    onChange?: (id: IDable<ChordLine>) => void;
 }
 
 const WithSection: React.FC<WithSectionProps> = (
@@ -46,21 +46,29 @@ const WithSection: React.FC<WithSectionProps> = (
         onEndEdit: finishEdit,
     };
 
-    const handleLabelChange = (newValue: string) => {
-        const changed = props.chordLine.setSectionName(newValue);
+    const { chordLine, songDispatch } = props;
 
-        if (changed) {
-            props.onChange?.(props.chordLine);
-        }
-    };
+    const handleLabelChange = useCallback(
+        (newValue: string) => {
+            songDispatch({
+                type: "set-section-label",
+                lineID: chordLine,
+                label: newValue,
+            });
+        },
+        [chordLine, songDispatch]
+    );
 
-    const handleTimeChange = (newValue: number | null) => {
-        const changed = props.chordLine.setSectionTime(newValue);
-
-        if (changed) {
-            props.onChange?.(props.chordLine);
-        }
-    };
+    const handleTimeChange = useCallback(
+        (newValue: number | null) => {
+            songDispatch({
+                type: "set-section-time",
+                lineID: chordLine,
+                time: newValue,
+            });
+        },
+        [chordLine, songDispatch]
+    );
 
     const childElement: React.ReactElement = props.children(startEdit);
     const section = props.chordLine.section;
@@ -107,4 +115,4 @@ const WithSection: React.FC<WithSectionProps> = (
     );
 };
 
-export default WithSection;
+export default React.memo(WithSection);

--- a/src/components/edit/lyric_input/LyricInput.tsx
+++ b/src/components/edit/lyric_input/LyricInput.tsx
@@ -50,7 +50,8 @@ interface LyricInputProps extends StyledComponentProps {
 const LyricInput: React.FC<LyricInputProps> = (
     props: LyricInputProps
 ): JSX.Element => {
-    const contentEditableRef: React.RefObject<HTMLSpanElement> = React.createRef();
+    const contentEditableRef: React.RefObject<HTMLSpanElement> =
+        React.createRef();
 
     const value = (): Lyric => {
         const elem = contentEditableElement(contentEditableRef);

--- a/src/components/edit/lyric_input/LyricInput.tsx
+++ b/src/components/edit/lyric_input/LyricInput.tsx
@@ -43,7 +43,7 @@ interface LyricInputProps extends StyledComponentProps {
     onSpecialBackspace: PlainFn;
     onSpecialEnter: (splitIndex: number) => void;
     onLyricOverflow: (overflowContent: Lyric[]) => void;
-    onJSONPaste: (jsonStr: string) => boolean;
+    onJSONPaste: (jsonStr: string) => [boolean, PlainFn | null];
     variant?: TypographyVariant;
 }
 
@@ -85,11 +85,13 @@ const LyricInput: React.FC<LyricInputProps> = (
     const pasteHandlerProps: PasteHandlerProps = {
         contentEditableRef: contentEditableRef,
         pasteJSONCallback: (payload: string): boolean => {
-            const handled = props.onJSONPaste(payload);
-            if (handled) {
+            const [canHandle, executePaste] = props.onJSONPaste(payload);
+            if (canHandle) {
                 finish(value());
+                executePaste?.();
             }
-            return handled;
+
+            return canHandle;
         },
         pastePlainTextCallback: (firstLine: Lyric, restOfLines: Lyric[]) => {
             finish(firstLine);

--- a/src/components/edit/menu/ChordPaperMenu.tsx
+++ b/src/components/edit/menu/ChordPaperMenu.tsx
@@ -21,10 +21,11 @@ import { useCloudCreateSong } from "./cloudSave";
 import { useLoadMenuAction } from "./load";
 import { useSaveMenuAction } from "./save";
 import TransposeMenu from "./TransposeMenu";
+import { ChordSongAction } from "../../reducer/reducer";
 
 interface ChordPaperMenuProps {
     song: ChordSong;
-    onSongChanged: (song: ChordSong) => void;
+    songDispatch: React.Dispatch<ChordSongAction>;
     onPlay?: PlainFn;
 }
 
@@ -46,7 +47,10 @@ const ChordPaperMenu: React.FC<ChordPaperMenuProps> = (
     const { enqueueSnackbar } = useSnackbar();
 
     const user = React.useContext(UserContext);
-    const loadAction = useLoadMenuAction(props.onSongChanged, enqueueSnackbar);
+
+    const setSong = (loadedSong: ChordSong) =>
+        props.songDispatch({ type: "set-song", song: loadedSong });
+    const loadAction = useLoadMenuAction(setSong, enqueueSnackbar);
     const saveAction = useSaveMenuAction(props.song);
     const cloudSaveAction = useCloudCreateSong();
 
@@ -74,11 +78,11 @@ const ChordPaperMenu: React.FC<ChordPaperMenuProps> = (
         return (
             <TransposeMenu
                 song={props.song}
+                songDispatch={props.songDispatch}
                 open
                 onClose={() => {
                     setTransposeMenuOpen(false);
                 }}
-                onSongChanged={props.onSongChanged}
             ></TransposeMenu>
         );
     }

--- a/src/components/edit/menu/ChordPaperMenu.tsx
+++ b/src/components/edit/menu/ChordPaperMenu.tsx
@@ -49,7 +49,7 @@ const ChordPaperMenu: React.FC<ChordPaperMenuProps> = (
     const user = React.useContext(UserContext);
 
     const setSong = (loadedSong: ChordSong) =>
-        props.songDispatch({ type: "set-song", song: loadedSong });
+        props.songDispatch({ type: "replace-song", newSong: loadedSong });
     const loadAction = useLoadMenuAction(setSong, enqueueSnackbar);
     const saveAction = useSaveMenuAction(props.song);
     const cloudSaveAction = useCloudCreateSong();

--- a/src/components/edit/menu/TransposeMenu.tsx
+++ b/src/components/edit/menu/TransposeMenu.tsx
@@ -15,14 +15,14 @@ import { withStyles } from "@material-ui/styles";
 import React, { useState } from "react";
 import { ChordSong } from "../../../common/ChordModel/ChordSong";
 import { AllNotes, Note } from "../../../common/music/foundation/Note";
-import { transposeSong } from "../../../common/music/transpose/Transpose";
 import { PlainFn } from "../../../common/PlainFn";
+import { ChordSongAction } from "../../reducer/reducer";
 
 interface TransposeMenuProps {
     open: boolean;
     song: ChordSong;
+    songDispatch: React.Dispatch<ChordSongAction>;
     onClose: PlainFn;
-    onSongChanged: (song: ChordSong) => void;
 }
 
 const FormControl = withStyles((theme: Theme) => ({
@@ -63,12 +63,12 @@ const TransposeMenu: React.FC<TransposeMenuProps> = (
     };
 
     const handleTransposeAction = (): void => {
-        transposeSong(
-            props.song,
-            keySelection.originalKey,
-            keySelection.transposedKey
-        );
-        props.onSongChanged(props.song);
+        props.songDispatch({
+            type: "transpose",
+            originalKey: keySelection.originalKey,
+            transposeKey: keySelection.transposedKey,
+        });
+
         props.onClose();
     };
 

--- a/src/components/reducer/reducer.ts
+++ b/src/components/reducer/reducer.ts
@@ -21,12 +21,12 @@ const chordSongReducer = (
 
 export const useChordSongReducer = (
     initialSong: ChordSong,
-    onChange: (song: ChordSong) => void
+    onChange?: (song: ChordSong) => void
 ): [ChordSong, React.Dispatch<ChordSongAction>] => {
     const reducerWithChangeCallback = useCallback(
         (song: ChordSong, action: ChordSongAction): ChordSong => {
             const newSong: ChordSong = chordSongReducer(song, action);
-            onChange(newSong);
+            onChange?.(newSong);
             return newSong;
         },
         [onChange]

--- a/src/components/reducer/reducer.ts
+++ b/src/components/reducer/reducer.ts
@@ -1,20 +1,140 @@
 import { useCallback, useReducer } from "react";
+import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
+import { IDable } from "../../common/ChordModel/Collection";
+import { Lyric } from "../../common/ChordModel/Lyric";
+import { Note } from "../../common/music/foundation/Note";
+import { transposeSong } from "../../common/music/transpose/Transpose";
 
-export type SetState = {
-    type: "set-state";
+type SetState = {
+    type: "set-song";
     song: ChordSong;
 };
 
-export type ChordSongAction = SetState;
+type SetHeader = {
+    type: "set-header";
+    title?: string;
+    composedBy?: string;
+    performedBy?: string;
+};
+
+type Transpose = {
+    type: "transpose";
+    originalKey: Note;
+    transposeKey: Note;
+};
+
+type AddLineBeginning = {
+    type: "add-line-beginning";
+};
+
+type AddLineAfter = {
+    type: "add-line-after";
+    lineID: IDable<ChordLine>;
+};
+
+type RemoveLine = {
+    type: "remove-line";
+    lineID: IDable<ChordLine>;
+};
+
+type SplitLine = {
+    type: "split-line";
+    lineID: IDable<ChordLine>;
+    splitIndex: number;
+};
+
+type JSONPaste = {
+    type: "json-paste";
+};
+
+type InsertOverflowLyrics = {
+    type: "insert-overflow-lyrics";
+    insertionLineID: IDable<ChordLine>;
+    overflowLyrics: Lyric[];
+};
+
+type ReplaceLineLyrics = {
+    type: "replace-line-lyrics";
+    lineID: IDable<ChordLine>;
+    newLyric: Lyric;
+};
+
+export type ChordSongAction =
+    | SetState
+    | SetHeader
+    | AddLineBeginning
+    | AddLineAfter
+    | RemoveLine
+    | SplitLine
+    | InsertOverflowLyrics
+    | ReplaceLineLyrics
+    | Transpose;
 
 const chordSongReducer = (
     song: ChordSong,
     action: ChordSongAction
 ): ChordSong => {
     switch (action.type) {
-        case "set-state": {
+        case "set-song": {
             return action.song.clone();
+        }
+
+        case "set-header": {
+            if (action.title !== undefined) {
+                song.title = action.title;
+            }
+
+            if (action.composedBy !== undefined) {
+                song.composedBy = action.composedBy;
+            }
+
+            if (action.performedBy !== undefined) {
+                song.performedBy = action.performedBy;
+            }
+
+            return song.clone();
+        }
+
+        case "add-line-beginning": {
+            song.addBeginning(new ChordLine());
+            return song.clone();
+        }
+
+        case "add-line-after": {
+            song.addAfter(action.lineID, new ChordLine());
+            return song.clone();
+        }
+
+        case "remove-line": {
+            song.remove(action.lineID);
+            return song.clone();
+        }
+
+        case "split-line": {
+            console.log("split line");
+            song.splitLine(action.lineID, action.splitIndex);
+            return song.clone();
+        }
+
+        case "replace-line-lyrics": {
+            const line = song.get(action.lineID);
+            line.replaceLyrics(action.newLyric);
+            return song.clone();
+        }
+
+        case "insert-overflow-lyrics": {
+            const newChordLines: ChordLine[] = action.overflowLyrics.map(
+                (newLyricLine: Lyric) => ChordLine.fromLyrics(newLyricLine)
+            );
+            song.addAfter(action.insertionLineID, ...newChordLines);
+            return song.clone();
+        }
+
+        case "transpose": {
+            transposeSong(song, action.originalKey, action.transposeKey);
+
+            return song.clone();
         }
     }
 };

--- a/src/components/reducer/reducer.ts
+++ b/src/components/reducer/reducer.ts
@@ -8,9 +8,9 @@ import { Lyric } from "../../common/ChordModel/Lyric";
 import { Note } from "../../common/music/foundation/Note";
 import { transposeSong } from "../../common/music/transpose/Transpose";
 
-type SetState = {
-    type: "set-song";
-    song: ChordSong;
+type ReplaceSong = {
+    type: "replace-song";
+    newSong: ChordSong;
 };
 
 type SetHeader = {
@@ -71,8 +71,8 @@ type ReplaceLineLyrics = {
     newLyric: Lyric;
 };
 
-type ChangeChord = {
-    type: "change-chord";
+type SetChord = {
+    type: "set-chord";
     lineID: IDable<ChordLine>;
     blockID: IDable<ChordBlock>;
     newChord: string;
@@ -102,7 +102,7 @@ type SetSection = {
 };
 
 export type ChordSongAction =
-    | SetState
+    | ReplaceSong
     | SetHeader
     | AddLine
     | RemoveLine
@@ -113,7 +113,7 @@ export type ChordSongAction =
     | InsertOverflowLyrics
     | ReplaceLineLyrics
     | DragAndDropChord
-    | ChangeChord
+    | SetChord
     | SplitBlock
     | SetSection
     | Transpose;
@@ -127,8 +127,8 @@ const chordSongReducer = (
     song = lodash.cloneDeep(song);
 
     switch (action.type) {
-        case "set-song": {
-            return action.song.clone();
+        case "replace-song": {
+            return action.newSong.clone();
         }
 
         case "set-header": {
@@ -210,7 +210,7 @@ const chordSongReducer = (
             return song.clone();
         }
 
-        case "change-chord": {
+        case "set-chord": {
             const line: ChordLine = song.get(action.lineID);
             line.setChord(action.blockID, action.newChord);
             return song.clone();

--- a/src/components/reducer/reducer.ts
+++ b/src/components/reducer/reducer.ts
@@ -207,13 +207,6 @@ const chordSongReducer = (
         }
 
         case "replace-line-lyrics": {
-            // TODO:
-            // issue in paste handler -
-            // JSON paste fires first, and then removes the existing line
-            // and then this concludes, but the line has already been removed
-            // and can't be called without crashing
-            // const line = song.get(action.lineID);
-            // line.replaceLyrics(action.newLyric);
             const line: ChordLine = song.get(action.lineID);
 
             line.replaceLyrics(action.newLyric);

--- a/src/components/reducer/reducer.ts
+++ b/src/components/reducer/reducer.ts
@@ -5,6 +5,7 @@ import { IDable } from "../../common/ChordModel/Collection";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { Note } from "../../common/music/foundation/Note";
 import { transposeSong } from "../../common/music/transpose/Transpose";
+import lodash from "lodash";
 
 type SetState = {
     type: "set-song";
@@ -44,6 +45,11 @@ type SplitLine = {
     splitIndex: number;
 };
 
+type MergeLines = {
+    type: "merge-lines";
+    latterLineID: IDable<ChordLine>;
+};
+
 type JSONPaste = {
     type: "json-paste";
 };
@@ -67,6 +73,7 @@ export type ChordSongAction =
     | AddLineAfter
     | RemoveLine
     | SplitLine
+    | MergeLines
     | InsertOverflowLyrics
     | ReplaceLineLyrics
     | Transpose;
@@ -112,8 +119,16 @@ const chordSongReducer = (
         }
 
         case "split-line": {
-            console.log("split line");
             song.splitLine(action.lineID, action.splitIndex);
+            return song.clone();
+        }
+
+        case "merge-lines": {
+            const merged = song.mergeLineWithPrevious(action.latterLineID);
+            if (!merged) {
+                return song;
+            }
+
             return song.clone();
         }
 

--- a/src/components/reducer/reducer.ts
+++ b/src/components/reducer/reducer.ts
@@ -1,0 +1,36 @@
+import { useCallback, useReducer } from "react";
+import { ChordSong } from "../../common/ChordModel/ChordSong";
+
+export type SetState = {
+    type: "set-state";
+    song: ChordSong;
+};
+
+export type ChordSongAction = SetState;
+
+const chordSongReducer = (
+    song: ChordSong,
+    action: ChordSongAction
+): ChordSong => {
+    switch (action.type) {
+        case "set-state": {
+            return action.song.clone();
+        }
+    }
+};
+
+export const useChordSongReducer = (
+    initialSong: ChordSong,
+    onChange: (song: ChordSong) => void
+): [ChordSong, React.Dispatch<ChordSongAction>] => {
+    const reducerWithChangeCallback = useCallback(
+        (song: ChordSong, action: ChordSongAction): ChordSong => {
+            const newSong: ChordSong = chordSongReducer(song, action);
+            onChange(newSong);
+            return newSong;
+        },
+        [onChange]
+    );
+
+    return useReducer(reducerWithChangeCallback, initialSong);
+};

--- a/src/components/reducer/reducer.ts
+++ b/src/components/reducer/reducer.ts
@@ -7,6 +7,7 @@ import { IDable } from "../../common/ChordModel/Collection";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { Note } from "../../common/music/foundation/Note";
 import { transposeSong } from "../../common/music/transpose/Transpose";
+import lodash from "lodash";
 
 type SetState = {
     type: "set-song";
@@ -128,6 +129,10 @@ const chordSongReducer = (
     action: ChordSongAction,
     enqueueSnackbar: ProviderContext["enqueueSnackbar"]
 ): ChordSong => {
+    // TODO: performance killer
+    // need to change this into immutable object pattern
+    song = lodash.cloneDeep(song);
+
     switch (action.type) {
         case "set-song": {
             return action.song.clone();
@@ -200,7 +205,9 @@ const chordSongReducer = (
             // and can't be called without crashing
             // const line = song.get(action.lineID);
             // line.replaceLyrics(action.newLyric);
-            action.line.replaceLyrics(action.newLyric);
+            const line: ChordLine = song.get(action.lineID);
+
+            line.replaceLyrics(action.newLyric);
             return song.clone();
         }
 

--- a/src/components/reducer/reducer.ts
+++ b/src/components/reducer/reducer.ts
@@ -20,6 +20,11 @@ type SetHeader = {
     performedBy?: string;
 };
 
+type SetLastSavedAt = {
+    type: "set-last-saved-at";
+    lastSavedAt: Date | null;
+};
+
 type Transpose = {
     type: "transpose";
     originalKey: Note;
@@ -104,6 +109,7 @@ type SetSection = {
 export type ChordSongAction =
     | ReplaceSong
     | SetHeader
+    | SetLastSavedAt
     | AddLine
     | RemoveLine
     | BatchInsertLines
@@ -144,6 +150,11 @@ const chordSongReducer = (
                 song.performedBy = action.performedBy;
             }
 
+            return song.clone();
+        }
+
+        case "set-last-saved-at": {
+            song.lastSavedAt = action.lastSavedAt;
             return song.clone();
         }
 
@@ -282,12 +293,12 @@ const chordSongReducer = (
 
 export const useChordSongReducer = (
     initialSong: ChordSong,
-    onChange?: (song: ChordSong) => void
+    onChange?: (newSong: ChordSong, action: ChordSongAction) => void
 ): [ChordSong, React.Dispatch<ChordSongAction>] => {
     const reducerWithChangeCallback = useCallback(
         (song: ChordSong, action: ChordSongAction): ChordSong => {
             const newSong: ChordSong = chordSongReducer(song, action);
-            onChange?.(newSong);
+            onChange?.(newSong, action);
 
             return newSong;
         },

--- a/src/components/tutorial/Playground.tsx
+++ b/src/components/tutorial/Playground.tsx
@@ -30,12 +30,7 @@ interface PlaygroundProps {
 const Playground: React.FC<PlaygroundProps> = (
     props: PlaygroundProps
 ): JSX.Element => {
-    const songChangeHandler = (updatedSong: ChordSong) => {};
-
-    const [song, songDispatch] = useChordSongReducer(
-        props.initialSong,
-        songChangeHandler
-    );
+    const [song, songDispatch] = useChordSongReducer(props.initialSong);
 
     const [finish, setFinish] = useState(false);
 
@@ -55,11 +50,7 @@ const Playground: React.FC<PlaygroundProps> = (
     return (
         <Badge badgeContent={<CheckCircleIcon />} invisible={!finish}>
             <Paper elevation={1}>
-                <ChordPaperBody
-                    song={song}
-                    songDispatch={songDispatch}
-                    onSongChanged={songChangeHandler}
-                />
+                <ChordPaperBody song={song} songDispatch={songDispatch} />
             </Paper>
         </Badge>
     );

--- a/src/components/tutorial/Playground.tsx
+++ b/src/components/tutorial/Playground.tsx
@@ -8,6 +8,7 @@ import UnstyledCheckCircleIcon from "@material-ui/icons/CheckCircle";
 import React, { useState } from "react";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
 import ChordPaperBody from "../edit/ChordPaperBody";
+import { useChordSongReducer } from "../reducer/reducer";
 
 const CheckCircleIcon = withStyles((theme: Theme) => ({
     root: {
@@ -29,13 +30,16 @@ interface PlaygroundProps {
 const Playground: React.FC<PlaygroundProps> = (
     props: PlaygroundProps
 ): JSX.Element => {
-    const [song, setSong] = useState<ChordSong>(props.initialSong);
-    const [finish, setFinish] = useState(false);
-
     const songChangeHandler = (updatedSong: ChordSong) => {
-        setSong(updatedSong.clone());
         checkExpected(updatedSong);
     };
+
+    //TODO: more to wrap up here
+    const [song, songDispatch] = useChordSongReducer(
+        props.initialSong,
+        songChangeHandler
+    );
+    const [finish, setFinish] = useState(false);
 
     const checkExpected = (updatedSong: ChordSong) => {
         // don't undo the green check if it's already been passing
@@ -54,7 +58,11 @@ const Playground: React.FC<PlaygroundProps> = (
     return (
         <Badge badgeContent={<CheckCircleIcon />} invisible={!finish}>
             <Paper elevation={1}>
-                <ChordPaperBody song={song} onSongChanged={songChangeHandler} />
+                <ChordPaperBody
+                    song={song}
+                    songDispatch={songDispatch}
+                    onSongChanged={songChangeHandler}
+                />
             </Paper>
         </Badge>
     );

--- a/src/components/tutorial/Playground.tsx
+++ b/src/components/tutorial/Playground.tsx
@@ -5,7 +5,7 @@ import {
     withStyles,
 } from "@material-ui/core";
 import UnstyledCheckCircleIcon from "@material-ui/icons/CheckCircle";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
 import ChordPaperBody from "../edit/ChordPaperBody";
 import { useChordSongReducer } from "../reducer/reducer";
@@ -30,30 +30,27 @@ interface PlaygroundProps {
 const Playground: React.FC<PlaygroundProps> = (
     props: PlaygroundProps
 ): JSX.Element => {
-    const songChangeHandler = (updatedSong: ChordSong) => {
-        checkExpected(updatedSong);
-    };
+    const songChangeHandler = (updatedSong: ChordSong) => {};
 
-    //TODO: more to wrap up here
     const [song, songDispatch] = useChordSongReducer(
         props.initialSong,
         songChangeHandler
     );
+
     const [finish, setFinish] = useState(false);
 
-    const checkExpected = (updatedSong: ChordSong) => {
+    const { expectedSong } = props;
+
+    useEffect(() => {
         // don't undo the green check if it's already been passing
         if (finish) {
             return;
         }
 
-        if (
-            props.expectedSong !== undefined &&
-            props.expectedSong.contentEquals(updatedSong)
-        ) {
+        if (expectedSong !== undefined && expectedSong.contentEquals(song)) {
             setFinish(true);
         }
-    };
+    }, [song, expectedSong, finish, setFinish]);
 
     return (
         <Badge badgeContent={<CheckCircleIcon />} invisible={!finish}>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,15 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import * as serviceWorker from './serviceWorker';
+import React from "react";
+import ReactDOM from "react-dom";
+import "./index.css";
+import App from "./App";
+import * as serviceWorker from "./serviceWorker";
 
 ReactDOM.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-  document.getElementById('root')
+    // TODO - fix when using immutable
+    // <React.StrictMode>
+    <App />,
+    // </React.StrictMode>,
+    document.getElementById("root")
 );
 
 // If you want your app to work offline and load faster, you can change

--- a/src/test/app_menu.test.tsx
+++ b/src/test/app_menu.test.tsx
@@ -9,29 +9,29 @@ beforeAll(gapiStub);
 describe("App side menu", () => {
     let findByTestIdChain: FindByTestIdChainFn;
     beforeEach(async () => {
-        const { findByTestId } = render(<App />);
-        findByTestIdChain = getFindByTestIdChain(findByTestId);
+        const { findAllByTestId } = render(<App />);
+        findByTestIdChain = getFindByTestIdChain(findAllByTestId);
     });
 
     test("Music page", async () => {
         // navigate away, and back
-        const aboutButton = await findByTestIdChain("Menu-AboutButton");
+        const aboutButton = await findByTestIdChain(["Menu-AboutButton", 0]);
         expect(aboutButton).toBeInTheDocument();
         fireEvent.click(aboutButton);
 
-        const homeButton = await findByTestIdChain("Menu-HomeButton");
+        const homeButton = await findByTestIdChain(["Menu-HomeButton", 0]);
         expect(homeButton).toBeInTheDocument();
         fireEvent.click(homeButton);
 
-        expect(await findByTestIdChain("ChordPaper")).toBeInTheDocument();
+        expect(await findByTestIdChain(["ChordPaper", 0])).toBeInTheDocument();
     });
 
     test("About page", async () => {
         // navigate away, and back
-        const aboutButton = await findByTestIdChain("Menu-AboutButton");
+        const aboutButton = await findByTestIdChain(["Menu-AboutButton", 0]);
         expect(aboutButton).toBeInTheDocument();
         fireEvent.click(aboutButton);
 
-        expect(await findByTestIdChain("About")).toBeInTheDocument();
+        expect(await findByTestIdChain(["About", 0])).toBeInTheDocument();
     });
 });

--- a/src/test/chords.test.tsx
+++ b/src/test/chords.test.tsx
@@ -35,31 +35,31 @@ const basicChordPaper = () => {
 
 describe("Rendering initial chords", () => {
     test("renders the chords", async () => {
-        const { findByTestId } = render(basicChordPaper());
-        const expectChordAndLyric = getExpectChordAndLyric(findByTestId);
+        const { findAllByTestId } = render(basicChordPaper());
+        const expectChordAndLyric = getExpectChordAndLyric(findAllByTestId);
 
         await expectChordAndLyric("C", "Fly me ", [
-            "Line-0",
-            "NoneditableLine",
-            "Block-0",
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 0],
         ]);
 
         await expectChordAndLyric("D", "to the moon", [
-            "Line-0",
-            "NoneditableLine",
-            "Block-1",
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 1],
         ]);
 
         await expectChordAndLyric("", "And let me play ", [
-            "Line-1",
-            "NoneditableLine",
-            "Block-0",
+            ["Line", 1],
+            ["NoneditableLine", 0],
+            ["Block", 0],
         ]);
 
         await expectChordAndLyric("E", "among the stars", [
-            "Line-1",
-            "NoneditableLine",
-            "Block-1",
+            ["Line", 1],
+            ["NoneditableLine", 0],
+            ["Block", 1],
         ]);
     });
 });
@@ -68,14 +68,14 @@ describe("Changing the chord", () => {
     let findByTestIdChain: FindByTestIdChainFn;
     let expectChordAndLyric: ExpectChordAndLyricFn;
     beforeEach(async () => {
-        const { findByTestId } = render(basicChordPaper());
-        findByTestIdChain = getFindByTestIdChain(findByTestId);
-        expectChordAndLyric = getExpectChordAndLyric(findByTestId);
+        const { findAllByTestId } = render(basicChordPaper());
+        findByTestIdChain = getFindByTestIdChain(findAllByTestId);
+        expectChordAndLyric = getExpectChordAndLyric(findAllByTestId);
         const chordSymbol = await findByTestIdChain(
-            "Line-0",
-            "NoneditableLine",
-            "Block-1",
-            "ChordSymbol"
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 1],
+            ["ChordSymbol", 0]
         );
 
         expect(chordSymbol).toBeInTheDocument();
@@ -85,12 +85,12 @@ describe("Changing the chord", () => {
     test("it takes input and retains new chord changes", async () => {
         const chordEdit = async () =>
             await findByTestIdChain(
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
-                "ChordEdit",
-                "TextInput",
-                "InnerInput"
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
+                ["ChordEdit", 0],
+                ["TextInput", 0],
+                ["InnerInput", 0]
             );
 
         changeInputText(await chordEdit(), "F7");
@@ -98,20 +98,20 @@ describe("Changing the chord", () => {
         pressKey(await chordEdit(), Keys.enter);
 
         await expectChordAndLyric("F7", "to the moon", [
-            "Line-0",
-            "NoneditableLine",
-            "Block-1",
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 1],
         ]);
     });
 
     test("it gets merged with previous block when chords are cleared", async () => {
         const chordEdit = await findByTestIdChain(
-            "Line-0",
-            "NoneditableLine",
-            "Block-1",
-            "ChordEdit",
-            "TextInput",
-            "InnerInput"
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 1],
+            ["ChordEdit", 0],
+            ["TextInput", 0],
+            ["InnerInput", 0]
         );
 
         changeInputText(chordEdit, "");
@@ -119,9 +119,9 @@ describe("Changing the chord", () => {
         pressKey(chordEdit, Keys.enter);
 
         await expectChordAndLyric("C", "Fly me to the moon", [
-            "Line-0",
-            "NoneditableLine",
-            "Block-0",
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 0],
         ]);
     });
 });
@@ -133,16 +133,16 @@ describe("inserting a chord", () => {
     let expectChordAndLyric: ExpectChordAndLyricFn;
 
     beforeEach(async () => {
-        const { findByTestId } = render(basicChordPaper());
-        findByTestIdChain = getFindByTestIdChain(findByTestId);
-        expectChordAndLyric = getExpectChordAndLyric(findByTestId);
+        const { findAllByTestId } = render(basicChordPaper());
+        findByTestIdChain = getFindByTestIdChain(findAllByTestId);
+        expectChordAndLyric = getExpectChordAndLyric(findAllByTestId);
 
         const editButton = await findByTestIdChain(
-            "Line-0",
-            "NoneditableLine",
-            "Block-1",
-            "TokenBox-2",
-            "ChordEditButton"
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 1],
+            ["TokenBox-2", 0],
+            ["ChordEditButton", 0]
         );
 
         expect(editButton).toBeInTheDocument();
@@ -150,12 +150,12 @@ describe("inserting a chord", () => {
 
         chordEdit = async () =>
             await findByTestIdChain(
-                "Line-0",
-                "NoneditableLine",
-                "Block-2", // the block should be split, so the chord happens on the next block
-                "ChordEdit",
-                "TextInput",
-                "InnerInput"
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 2], // the block should be split, so the chord happens on the next block
+                ["ChordEdit", 0],
+                ["TextInput", 0],
+                ["InnerInput", 0]
             );
     });
 
@@ -165,15 +165,15 @@ describe("inserting a chord", () => {
         pressKey(await chordEdit(), Keys.enter);
 
         await expectChordAndLyric("D", "to ", [
-            "Line-0",
-            "NoneditableLine",
-            "Block-1",
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 1],
         ]);
 
         await expectChordAndLyric("Am7", "the moon", [
-            "Line-0",
-            "NoneditableLine",
-            "Block-2",
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 2],
         ]);
     });
 
@@ -183,9 +183,9 @@ describe("inserting a chord", () => {
         pressKey(await chordEdit(), Keys.enter);
 
         await expectChordAndLyric("D", "to the moon", [
-            "Line-0",
-            "NoneditableLine",
-            "Block-1",
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 1],
         ]);
     });
 });
@@ -195,23 +195,23 @@ describe("inserting a chord at a tab block", () => {
     let expectChordAndLyric: ExpectChordAndLyricFn;
 
     beforeEach(async () => {
-        const { findByTestId } = render(
+        const { findAllByTestId } = render(
             chordPaperFromLyrics([
                 "I\ue200never loved you fully in the way I could",
             ])
         );
-        findByTestIdChain = getFindByTestIdChain(findByTestId);
-        expectChordAndLyric = getExpectChordAndLyric(findByTestId);
+        findByTestIdChain = getFindByTestIdChain(findAllByTestId);
+        expectChordAndLyric = getExpectChordAndLyric(findAllByTestId);
     });
 
     test("it inserts the chord at the tab space and treats it as an atomic token", async () => {
         const insertChordAtTab = async () => {
             const editButton = await findByTestIdChain(
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
-                "TokenBox-1",
-                "ChordEditButton"
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
+                ["TokenBox-1", 0],
+                ["ChordEditButton", 0]
             );
 
             expect(editButton).toBeInTheDocument();
@@ -219,12 +219,12 @@ describe("inserting a chord at a tab block", () => {
 
             const chordEdit = async () =>
                 await findByTestIdChain(
-                    "Line-0",
-                    "NoneditableLine",
-                    "Block-1", // the block should be split, so the chord happens on the next block
-                    "ChordEdit",
-                    "TextInput",
-                    "InnerInput"
+                    ["Line", 0],
+                    ["NoneditableLine", 0],
+                    ["Block", 1], // the block should be split, so the chord happens on the next block
+                    ["ChordEdit", 0],
+                    ["TextInput", 0],
+                    ["InnerInput", 0]
                 );
             changeInputText(await chordEdit(), "Am7");
             pressKey(await chordEdit(), Keys.enter);
@@ -232,11 +232,11 @@ describe("inserting a chord at a tab block", () => {
 
         const insertChordAtLyricAfterTab = async () => {
             const editButton = await findByTestIdChain(
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
-                "TokenBox-1",
-                "ChordEditButton"
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
+                ["TokenBox-1", 0],
+                ["ChordEditButton", 0]
             );
 
             expect(editButton).toBeInTheDocument();
@@ -244,12 +244,12 @@ describe("inserting a chord at a tab block", () => {
 
             const chordEdit = async () =>
                 await findByTestIdChain(
-                    "Line-0",
-                    "NoneditableLine",
-                    "Block-2", // the block should be split, so the chord happens on the next block
-                    "ChordEdit",
-                    "TextInput",
-                    "InnerInput"
+                    ["Line", 0],
+                    ["NoneditableLine", 0],
+                    ["Block", 2], // the block should be split, so the chord happens on the next block
+                    ["ChordEdit", 0],
+                    ["TextInput", 0],
+                    ["InnerInput", 0]
                 );
             changeInputText(await chordEdit(), "D");
             pressKey(await chordEdit(), Keys.enter);
@@ -259,21 +259,25 @@ describe("inserting a chord at a tab block", () => {
         await insertChordAtLyricAfterTab();
 
         await expectChordAndLyric("", "I", [
-            "Line-0",
-            "NoneditableLine",
-            "Block-0",
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 0],
         ]);
 
         await expectChordAndLyric("Am7", "\ue200", [
-            "Line-0",
-            "NoneditableLine",
-            "Block-1",
+            ["Line", 0],
+            ["NoneditableLine", 0],
+            ["Block", 1],
         ]);
 
         await expectChordAndLyric(
             "D",
             "never loved you fully in the way I could",
-            ["Line-0", "NoneditableLine", "Block-2"]
+            [
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 2],
+            ]
         );
     });
 });

--- a/src/test/common.tsx
+++ b/src/test/common.tsx
@@ -5,6 +5,7 @@ import { HelmetProvider } from "react-helmet-async";
 import { ChordSong } from "../common/ChordModel/ChordSong";
 import { Lyric } from "../common/ChordModel/Lyric";
 import ChordPaper from "../components/edit/ChordPaper";
+import DragAndDrop from "../components/edit/DragAndDrop";
 import { UserContext } from "../components/user/userContext";
 import { withSongContext } from "../components/WithSongContext";
 
@@ -15,7 +16,9 @@ export const withProviders = (children: React.ReactNode) => {
         <UserContext.Provider value={null}>
             <HelmetProvider>
                 <ThemeProvider theme={createMuiTheme()}>
-                    <SnackbarProvider>{children}</SnackbarProvider>
+                    <DragAndDrop>
+                        <SnackbarProvider>{children}</SnackbarProvider>
+                    </DragAndDrop>
                 </ThemeProvider>
             </HelmetProvider>
         </UserContext.Provider>

--- a/src/test/demo.test.tsx
+++ b/src/test/demo.test.tsx
@@ -30,19 +30,19 @@ describe("Renders", () => {
     });
 
     test("renders at least a line", async () => {
-        const { findByTestId } = render(demo());
-        const expectChordAndLyric = getExpectChordAndLyric(findByTestId);
+        const { findAllByTestId } = render(demo());
+        const expectChordAndLyric = getExpectChordAndLyric(findAllByTestId);
 
         await expectChordAndLyric("Em7", "We're no strangers to ", [
-            "Line-4",
-            "NoneditableLine",
-            "Block-0",
+            ["Line", 4],
+            ["NoneditableLine", 0],
+            ["Block", 0],
         ]);
 
         await expectChordAndLyric("A7", "love", [
-            "Line-4",
-            "NoneditableLine",
-            "Block-1",
+            ["Line", 4],
+            ["NoneditableLine", 0],
+            ["Block", 1],
         ]);
     });
 });

--- a/src/test/lyrics.test.tsx
+++ b/src/test/lyrics.test.tsx
@@ -37,8 +37,8 @@ const basicChordPaper = () => {
     return chordPaperFromLyrics(lyrics);
 };
 
-const getFindByTestId = (chordSong: ChordSong) => {
-    return render(chordPaperFromSong(chordSong)).findByTestId;
+const getFindAllByTestId = (chordSong: ChordSong) => {
+    return render(chordPaperFromSong(chordSong)).findAllByTestId;
 };
 
 describe("Rendering initial lyrics", () => {
@@ -66,7 +66,10 @@ describe("Plain text edit action", () => {
     let asyncExpectChordAndLyric: ExpectChordAndLyricFn;
 
     const clickFirstLine = async () => {
-        const line = await findByTestIdChain("Line-0", "NoneditableLine");
+        const line = await findByTestIdChain(
+            ["Line", 0],
+            ["NoneditableLine", 0]
+        );
         expect(line).toBeInTheDocument();
         fireEvent.mouseOver(line);
         fireEvent.click(line);
@@ -74,7 +77,11 @@ describe("Plain text edit action", () => {
 
     const changeLyric = async (newLyric: string) => {
         const findContentEditableElem = async (): Promise<HTMLElement> => {
-            return findByTestIdChain("Line-0", "LyricInput", "InnerInput");
+            return findByTestIdChain(
+                ["Line", 0],
+                ["LyricInput", 0],
+                ["InnerInput", 0]
+            );
         };
 
         expect(await findContentEditableElem()).toBeInTheDocument();
@@ -86,7 +93,7 @@ describe("Plain text edit action", () => {
         beforeEach(async () => {
             const song = new ChordSong();
 
-            const findByTestId = getFindByTestId(song);
+            const findByTestId = getFindAllByTestId(song);
             findByTestIdChain = getFindByTestIdChain(findByTestId);
             asyncExpectChordAndLyric = getExpectChordAndLyric(findByTestId);
 
@@ -97,9 +104,9 @@ describe("Plain text edit action", () => {
             await changeLyric("Never Gonna Give You Up");
 
             await asyncExpectChordAndLyric("", "Never Gonna Give You Up", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
         });
     });
@@ -110,7 +117,7 @@ describe("Plain text edit action", () => {
                 new Lyric("We've known each other for so long"),
             ]);
 
-            const findByTestId = getFindByTestId(song);
+            const findByTestId = getFindAllByTestId(song);
             findByTestIdChain = getFindByTestIdChain(findByTestId);
             asyncExpectChordAndLyric = getExpectChordAndLyric(findByTestId);
 
@@ -121,9 +128,9 @@ describe("Plain text edit action", () => {
             await changeLyric("Never Gonna Give You Up");
 
             await asyncExpectChordAndLyric("", "Never Gonna Give You Up", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
         });
     });
@@ -138,20 +145,27 @@ describe("Tab spacing", () => {
             new Lyric("Put some old bay on it and now it's a crab claw"),
         ]);
 
-        const findByTestId = getFindByTestId(song);
+        const findByTestId = getFindAllByTestId(song);
         findByTestIdChain = getFindByTestIdChain(findByTestId);
         asyncExpectChordAndLyric = getExpectChordAndLyric(findByTestId);
     });
 
     const clickFirstLine = async () => {
-        const line = await findByTestIdChain("Line-0", "NoneditableLine");
+        const line = await findByTestIdChain(
+            ["Line", 0],
+            ["NoneditableLine", 0]
+        );
         expect(line).toBeInTheDocument();
         fireEvent.mouseOver(line);
         fireEvent.click(line);
     };
 
     const contentEditableElem = async (): Promise<HTMLElement> => {
-        return findByTestIdChain("Line-0", "LyricInput", "InnerInput");
+        return findByTestIdChain(
+            ["Line", 0],
+            ["LyricInput", 0],
+            ["InnerInput", 0]
+        );
     };
 
     describe("simple insertion", () => {
@@ -169,9 +183,9 @@ describe("Tab spacing", () => {
                 pressKey(await contentEditableElem(), Keys.enter);
 
                 await asyncExpectChordAndLyric("", expectedLyrics, [
-                    "Line-0",
-                    "NoneditableLine",
-                    "Block-0",
+                    ["Line", 0],
+                    ["NoneditableLine", 0],
+                    ["Block", 0],
                 ]);
             });
         };
@@ -226,14 +240,22 @@ describe("Tab spacing", () => {
             await asyncExpectChordAndLyric(
                 "",
                 "Put some old bay on it and now it's a crab claw\ue200",
-                ["Line-0", "NoneditableLine", "Block-0"]
+                [
+                    ["Line", 0],
+                    ["NoneditableLine", 0],
+                    ["Block", 0],
+                ]
             );
 
             await backspaceTab();
             await asyncExpectChordAndLyric(
                 "",
                 "Put some old bay on it and now it's a crab claw",
-                ["Line-0", "NoneditableLine", "Block-0"]
+                [
+                    ["Line", 0],
+                    ["NoneditableLine", 0],
+                    ["Block", 0],
+                ]
             );
         });
     });
@@ -310,11 +332,14 @@ describe("Edit action with chords", () => {
             ]),
         ]);
 
-        const findByTestId = getFindByTestId(song);
+        const findByTestId = getFindAllByTestId(song);
         findByTestIdChain = getFindByTestIdChain(findByTestId);
         expectChordAndLyric = getExpectChordAndLyric(findByTestId);
 
-        const line = await findByTestIdChain("Line-0", "NoneditableLine");
+        const line = await findByTestIdChain(
+            ["Line", 0],
+            ["NoneditableLine", 0]
+        );
         expect(line).toBeInTheDocument();
         fireEvent.mouseOver(line);
 
@@ -323,7 +348,11 @@ describe("Edit action with chords", () => {
 
     const changeLyric = async (newLyric: string) => {
         const findInputElem = async (): Promise<HTMLElement> => {
-            return findByTestIdChain("Line-0", "LyricInput", "InnerInput");
+            return findByTestIdChain(
+                ["Line", 0],
+                ["LyricInput", 0],
+                ["InnerInput", 0]
+            );
         };
 
         expect(await findInputElem()).toBeInTheDocument();
@@ -338,15 +367,15 @@ describe("Edit action with chords", () => {
             await changeLyric("It's your fault that I'm in trouble");
 
             await expectChordAndLyric("F", "It's your fault ", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("C", "that I'm in trouble", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
         });
     });
@@ -356,15 +385,15 @@ describe("Edit action with chords", () => {
             await changeLyric("It's your fault so I'm in trouble");
 
             await expectChordAndLyric("F", "It's your fault ", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("C", "so I'm in trouble", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
         });
 
@@ -372,15 +401,15 @@ describe("Edit action with chords", () => {
             await changeLyric("Not really my fault that I am trooble");
 
             await expectChordAndLyric("F", "Not really my fault ", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("C", "that I am trooble", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
         });
     });
@@ -390,15 +419,15 @@ describe("Edit action with chords", () => {
             await changeLyric("It's really your fault that I'm in trouble");
 
             await expectChordAndLyric("F", "It's really your fault ", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("C", "that I'm in trouble", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
         });
 
@@ -406,15 +435,15 @@ describe("Edit action with chords", () => {
             await changeLyric("It's your fault really that I'm in trouble");
 
             await expectChordAndLyric("F", "It's your fault really ", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("C", "that I'm in trouble", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
         });
 
@@ -422,21 +451,21 @@ describe("Edit action with chords", () => {
             await changeLyric("Verse: It's your fault that I'm in trouble");
 
             await expectChordAndLyric("", "Verse: ", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("F", "It's your fault ", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
 
             await expectChordAndLyric("C", "that I'm in trouble", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-2",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 2],
             ]);
         });
     });
@@ -446,15 +475,15 @@ describe("Edit action with chords", () => {
             await changeLyric("It's your that I'm in trouble");
 
             await expectChordAndLyric("F", "It's your ", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("C", "that I'm in trouble", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
         });
 
@@ -462,15 +491,15 @@ describe("Edit action with chords", () => {
             await changeLyric("It's your fault that I'm in");
 
             await expectChordAndLyric("F", "It's your fault ", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("C", "that I'm in", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
         });
 
@@ -478,15 +507,15 @@ describe("Edit action with chords", () => {
             await changeLyric("your fault that I'm in trouble");
 
             await expectChordAndLyric("F", "your fault ", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("C", "that I'm in trouble", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
         });
 
@@ -494,15 +523,15 @@ describe("Edit action with chords", () => {
             await changeLyric("It your fut hat I'm trouble");
 
             await expectChordAndLyric("F", "It your fut ", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("C", "hat I'm trouble", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
         });
 
@@ -510,15 +539,15 @@ describe("Edit action with chords", () => {
             await changeLyric("that I'm in trouble");
 
             await expectChordAndLyric("F", "\ue100", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("C", "that I'm in trouble", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
         });
 
@@ -526,15 +555,15 @@ describe("Edit action with chords", () => {
             await changeLyric("It's your fault");
 
             await expectChordAndLyric("F", "It's your fault", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-0",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 0],
             ]);
 
             await expectChordAndLyric("C", "\ue100", [
-                "Line-0",
-                "NoneditableLine",
-                "Block-1",
+                ["Line", 0],
+                ["NoneditableLine", 0],
+                ["Block", 1],
             ]);
         });
     });
@@ -545,16 +574,16 @@ describe("Add action", () => {
     let subject: () => Promise<void>;
 
     beforeEach(async () => {
-        const { findByTestId } = render(basicChordPaper());
+        const { findAllByTestId } = render(basicChordPaper());
 
-        findByTestIdChain = getFindByTestIdChain(findByTestId);
+        findByTestIdChain = getFindByTestIdChain(findAllByTestId);
 
-        const line = await findByTestIdChain("NewLine-2");
+        const line = await findByTestIdChain(["NewLine", 2]);
         expect(line).toBeInTheDocument();
 
         subject = async () => {
             fireEvent.mouseOver(line);
-            const addButton = await findByTestId("AddButton");
+            const addButton = (await findAllByTestId("AddButton"))[0];
             expect(addButton).toBeInTheDocument();
             fireEvent.click(addButton);
         };
@@ -562,14 +591,20 @@ describe("Add action", () => {
 
     it("adds a new empty line", async () => {
         await subject();
-        const newLine = await findByTestIdChain("Line-3", "NoneditableLine");
+        const newLine = await findByTestIdChain(
+            ["Line", 3],
+            ["NoneditableLine", 0]
+        );
         expect(newLine).toBeInTheDocument();
         expect(newLine).toHaveTextContent("", { normalizeWhitespace: true });
     });
 
     it("pushes the next line down", async () => {
         await subject();
-        const pushedLine = await findByTestIdChain("Line-4", "NoneditableLine");
+        const pushedLine = await findByTestIdChain(
+            ["Line", 4],
+            ["NoneditableLine", 0]
+        );
         expect(pushedLine).toBeInTheDocument();
 
         const lyrics = lyricsInElement(pushedLine);
@@ -587,9 +622,12 @@ describe("Remove action", () => {
         const rendered = render(basicChordPaper());
         queryByText = rendered.queryByText;
 
-        findByTestIdChain = getFindByTestIdChain(rendered.findByTestId);
+        findByTestIdChain = getFindByTestIdChain(rendered.findAllByTestId);
 
-        const line = await findByTestIdChain("Line-2", "NoneditableLine");
+        const line = await findByTestIdChain(
+            ["Line", 2],
+            ["NoneditableLine", 0]
+        );
         expect(line).toBeInTheDocument();
 
         const lyrics = lyricsInElement(line);
@@ -597,7 +635,7 @@ describe("Remove action", () => {
 
         subject = async () => {
             fireEvent.mouseOver(line);
-            const removeButton = await findByTestIdChain("RemoveButton");
+            const removeButton = await findByTestIdChain(["RemoveButton", 0]);
             expect(removeButton).toBeInTheDocument();
             fireEvent.click(removeButton);
         };
@@ -616,7 +654,10 @@ describe("Remove action", () => {
             queryByText(matchLyric("Never gonna run around"))
         );
 
-        const line = await findByTestIdChain("Line-2", "NoneditableLine");
+        const line = await findByTestIdChain(
+            ["Line", 2],
+            ["NoneditableLine", 0]
+        );
         const lyrics = lyricsInElement(line);
         expect(lyrics).toEqual("Never gonna make you cry");
     });

--- a/src/test/paste.test.tsx
+++ b/src/test/paste.test.tsx
@@ -5,6 +5,7 @@ import {
     FindByTestIdChainFn,
     getExpectChordAndLyric,
     getFindByTestIdChain,
+    TestIDParam,
 } from "./matcher";
 import { changeContentEditableText } from "./userEvent";
 
@@ -12,7 +13,7 @@ afterEach(cleanup);
 
 const startEdit = async (
     findByTestIdChain: FindByTestIdChainFn,
-    ...testIDPath: string[]
+    ...testIDPath: TestIDParam[]
 ) => {
     const line = await findByTestIdChain(...testIDPath);
     expect(line).toBeInTheDocument();
@@ -52,11 +53,15 @@ describe("Pasting Lyrics", () => {
 
         beforeEach(async () => {
             const chordPaper = chordPaperFromLyrics(["", "123"]);
-            const { findByTestId } = render(chordPaper);
-            findByTestIdChain = getFindByTestIdChain(findByTestId);
-            expectChordAndLyric = getExpectChordAndLyric(findByTestId);
+            const { findAllByTestId } = render(chordPaper);
+            findByTestIdChain = getFindByTestIdChain(findAllByTestId);
+            expectChordAndLyric = getExpectChordAndLyric(findAllByTestId);
 
-            await startEdit(findByTestIdChain, "Line-0", "NoneditableLine");
+            await startEdit(
+                findByTestIdChain,
+                ["Line", 0],
+                ["NoneditableLine", 0]
+            );
         });
 
         const pasteMultipleLinesTests = (carriageReturn: boolean) => {
@@ -64,9 +69,9 @@ describe("Pasting Lyrics", () => {
                 beforeEach(async () => {
                     const contentEditableElemFn = async () =>
                         await findByTestIdChain(
-                            "Line-0",
-                            "LyricInput",
-                            "InnerInput"
+                            ["Line", 0],
+                            ["LyricInput", 0],
+                            ["InnerInput", 0]
                         );
 
                     changeContentEditableText(
@@ -83,22 +88,22 @@ describe("Pasting Lyrics", () => {
 
                 test("it pastes in the first line", async () => {
                     await expectChordAndLyric("", "ABC", [
-                        "Line-0",
-                        "NoneditableLine",
+                        ["Line", 0],
+                        ["NoneditableLine", 0],
                     ]);
                 });
 
                 test("adds the other lines below the first line", async () => {
                     await expectChordAndLyric("", "as easy as", [
-                        "Line-1",
-                        "NoneditableLine",
+                        ["Line", 1],
+                        ["NoneditableLine", 0],
                     ]);
                 });
 
                 test("it pushes down the second line", async () => {
                     await expectChordAndLyric("", "123", [
-                        "Line-2",
-                        "NoneditableLine",
+                        ["Line", 2],
+                        ["NoneditableLine", 0],
                     ]);
                 });
             });
@@ -122,20 +127,24 @@ describe("Pasting Lyrics", () => {
                 "AB",
                 "Are simple as do re mi",
             ]);
-            const { findByTestId } = render(chordPaper);
-            findByTestIdChain = getFindByTestIdChain(findByTestId);
-            expectChordAndLyric = getExpectChordAndLyric(findByTestId);
+            const { findAllByTestId } = render(chordPaper);
+            findByTestIdChain = getFindByTestIdChain(findAllByTestId);
+            expectChordAndLyric = getExpectChordAndLyric(findAllByTestId);
 
-            await startEdit(findByTestIdChain, "Line-0", "NoneditableLine");
+            await startEdit(
+                findByTestIdChain,
+                ["Line", 0],
+                ["NoneditableLine", 0]
+            );
         });
 
         const pasteMultipleLinesTests = (carriageReturn: boolean) => {
             describe("pasting multiple lines", () => {
                 beforeEach(async () => {
                     const input = await findByTestIdChain(
-                        "Line-0",
-                        "LyricInput",
-                        "InnerInput"
+                        ["Line", 0],
+                        ["LyricInput", 0],
+                        ["InnerInput", 0]
                     );
 
                     act(() => {
@@ -149,27 +158,27 @@ describe("Pasting Lyrics", () => {
                 });
                 test("it pastes in the remainder of the first line", async () => {
                     await expectChordAndLyric("", "ABC", [
-                        "Line-0",
-                        "NoneditableLine",
+                        ["Line", 0],
+                        ["NoneditableLine", 0],
                     ]);
                 });
 
                 test("adds the other lines below the first line", async () => {
                     await expectChordAndLyric("", "as easy as", [
-                        "Line-1",
-                        "NoneditableLine",
+                        ["Line", 1],
+                        ["NoneditableLine", 0],
                     ]);
 
                     await expectChordAndLyric("", "123", [
-                        "Line-2",
-                        "NoneditableLine",
+                        ["Line", 2],
+                        ["NoneditableLine", 0],
                     ]);
                 });
 
                 test("it pushes down the second line", async () => {
                     await expectChordAndLyric("", "Are simple as do re mi", [
-                        "Line-3",
-                        "NoneditableLine",
+                        ["Line", 3],
+                        ["NoneditableLine", 0],
                     ]);
                 });
             });


### PR DESCRIPTION
Right now, a giant performance hit happens because when anything changes, the entire component tree rerenders.

Memoizing can help, but since all the callbacks are different every time, it will still rerender needlessly.

Major change here is to replace useState with useReducer, which allows passing down a dispatch method which does not change between state changes. Then, all the callbacks also can be memoized and not cause unnecessary rerenders.

One thing that's not done yet is that the Chord model needs to be converted to an immutable model so that it can work better with the reducer. Right now I'm currently mocking that by doing a deep clone on every change, but that will negate the performance benefits. Next PR changes the chord model accordingly to be immutable.