### PR TITLE
Clip lyrics instead of multi line in overflow

### DIFF
--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -34,6 +34,9 @@ const HighlightableBox = withStyles({
         "&:hover": {
             backgroundColor: grey[100],
         },
+        whiteSpace: "nowrap",
+        overflow: "hidden",
+        textOverflow: "ellipsis",
     },
 })(Box);
 
@@ -109,7 +112,7 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
     );
 
     const basicLine = (startEdit: PlainFn) => (
-        <HighlightableBox data-testid={"NoneditableLine"} onClick={startEdit}>
+        <HighlightableBox data-testid="NoneditableLine" onClick={startEdit}>
             {blocks}
         </HighlightableBox>
     );


### PR DESCRIPTION
When lyrics extend past one line, the current behaviour is to display it on multiple lines. This is confusing, especially when editing.

Changing the behaviour to just clip the lyrics instead - since this is not the intended usage (for lyrics to overflow), it's just a temporary state until the user fixes it.