### PR TITLE
Fix: Track player width and controls change location when section label changes

### DIFF
--- a/src/components/track_player/MultiTrackPlayer.tsx
+++ b/src/components/track_player/MultiTrackPlayer.tsx
@@ -66,12 +66,18 @@ const Select = withStyles((theme: Theme) => ({
     },
 }))(UnstyledSelect);
 
-const FullPlayerContainer = withStyles((theme: Theme) => ({
-    root: {
-        backgroundColor: "white",
-        ...roundedTopCornersStyle(theme),
-    },
-}))(Box);
+const FullPlayerContainer = withStyles((theme: Theme) => {
+    const transportControlsWidth = theme.spacing(36);
+
+    return {
+        root: {
+            backgroundColor: "white",
+            minWidth: "50vw",
+            maxWidth: transportControlsWidth,
+            ...roundedTopCornersStyle(theme),
+        },
+    };
+})(Box);
 
 interface MultiTrackPlayerProps {
     show: boolean;

--- a/src/components/track_player/internal_player/ControlGroup.tsx
+++ b/src/components/track_player/internal_player/ControlGroup.tsx
@@ -6,6 +6,8 @@ export const ControlGroupBox = withStyles({
     root: {
         display: "flex",
         alignContent: "center",
+        flexShrink: 0,
+        flexGrow: 0,
     },
 })(Box);
 
@@ -26,7 +28,13 @@ interface ControlGroupProps {
 const ControlGroup: React.FC<ControlGroupProps> = (
     props: ControlGroupProps
 ): JSX.Element => {
-    const contents: React.ReactElement[] = props.children.map(
+    const isRealNode = (node: React.ReactNode): boolean => {
+        return node !== null && node !== undefined;
+    };
+
+    const realContents: React.ReactNode[] = props.children.filter(isRealNode);
+
+    const contents: React.ReactElement[] = realContents.map(
         (child: React.ReactNode, index: number) => {
             const divider = (
                 <VerticalMiddleDivider

--- a/src/components/track_player/internal_player/ControlPane.tsx
+++ b/src/components/track_player/internal_player/ControlPane.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@material-ui/core";
+import { Box, Theme } from "@material-ui/core";
 import { withStyles } from "@material-ui/styles";
 import React, { useEffect } from "react";
 import { PlainFn } from "../../../common/PlainFn";
@@ -31,11 +31,19 @@ interface ControlPaneProps {
     sectionLabel: string;
 }
 
-const ControlPaneBox = withStyles({
-    root: {
-        ...controlPaneStyle,
-        justifyContent: "space-between",
-    },
+const ControlPaneBox = withStyles((theme: Theme) => {
+    const buttonHeight = theme.spacing(5);
+    return {
+        root: {
+            ...controlPaneStyle,
+            justifyContent: "space-between",
+            // these series of CSS allows flex items
+            // to be "pushed off" when they run out of space
+            flexWrap: "wrap",
+            overflow: "hidden",
+            maxHeight: buttonHeight,
+        },
+    };
 })(Box);
 
 const ControlPane: React.FC<ControlPaneProps> = (
@@ -97,29 +105,13 @@ const ControlPane: React.FC<ControlPaneProps> = (
         }
 
         return (
-            <TransposeControl
-                transposeLevel={props.transpose.level}
-                onChange={props.transpose.onChange}
-            />
-        );
-    })();
-
-    const rightSideControls: JSX.Element = (() => {
-        const playrateControl = (
-            <PlayrateControl
-                playratePercentage={props.playrate.percentage}
-                onChange={props.playrate.onChange}
-            />
-        );
-
-        if (transposeControl === null) {
-            return playrateControl;
-        }
-
-        return (
             <ControlGroup dividers="left">
-                {transposeControl}
-                {playrateControl}
+                {[
+                    <TransposeControl
+                        transposeLevel={props.transpose.level}
+                        onChange={props.transpose.onChange}
+                    />,
+                ]}
             </ControlGroup>
         );
     })();
@@ -141,7 +133,15 @@ const ControlPane: React.FC<ControlPaneProps> = (
                 />
             </ControlGroup>
             <SectionLabel value={props.sectionLabel} />
-            {rightSideControls}
+            {transposeControl}
+            <ControlGroup dividers="left">
+                {[
+                    <PlayrateControl
+                        playratePercentage={props.playrate.percentage}
+                        onChange={props.playrate.onChange}
+                    />,
+                ]}
+            </ControlGroup>
         </ControlPaneBox>
     );
 };

--- a/src/components/track_player/internal_player/SectionLabel.tsx
+++ b/src/components/track_player/internal_player/SectionLabel.tsx
@@ -1,20 +1,22 @@
-import { Theme, Typography } from "@material-ui/core";
+import { Box, Theme, Typography } from "@material-ui/core";
 import { withStyles } from "@material-ui/styles";
 import React from "react";
 import { greyTextColour } from "../common";
-import { VerticalMiddleDivider } from "./ControlGroup";
 
-const SectionLabelTypography = withStyles((theme: Theme) => ({
+const SectionLabelBox = withStyles((theme: Theme) => ({
     root: {
         marginLeft: theme.spacing(1.5),
         marginRight: theme.spacing(1.5),
         color: greyTextColour,
+        flexShrink: 1,
+        flexGrow: 1,
+        display: "flex",
+        justifyContent: "center",
     },
-}))(Typography);
+}))(Box);
 
 interface SectionLabelProps {
     value: string;
-    divider?: boolean;
 }
 
 const SectionLabel: React.FC<SectionLabelProps> = (
@@ -25,14 +27,9 @@ const SectionLabel: React.FC<SectionLabelProps> = (
     }
 
     return (
-        <>
-            <SectionLabelTypography variant="body1">
-                {props.value}
-            </SectionLabelTypography>
-            {props.divider && (
-                <VerticalMiddleDivider orientation="vertical" flexItem />
-            )}
-        </>
+        <SectionLabelBox>
+            <Typography variant="body1">{props.value}</Typography>
+        </SectionLabelBox>
     );
 };
 

--- a/src/components/track_player/internal_player/reactPlayerProps.ts
+++ b/src/components/track_player/internal_player/reactPlayerProps.ts
@@ -16,7 +16,6 @@ const makeBasePlayerProps = (
         onPause: playerControls.onPause,
         onProgress: playerControls.onProgress,
         progressInterval: 500,
-        style: { minWidth: "50vw" },
         height: "auto",
         width: "unset",
         onKeyUp: (event: KeyboardEvent) => event.preventDefault(),


### PR DESCRIPTION
Right now, the track player just expands and contracts with their content size, which is primarily driven by the control pane. This results in a super confusing experience where your buttons and seek bar moves around as the song goes between sections (as section labels change the width of the player).

Fix here is to restrict width sizes to be at most 50vw, and at least the width of the transport controls (and if the window size is too small, then the width is the width of transport controls).

To maintain a sane control pane behaviour, the control pane now bumps off each unit (e.g. tempo control, pitch control, then section label) as space runs out.