### PR TITLE
Omit section data when copying lines

### DIFF
--- a/src/common/ChordModel/ChordLine.ts
+++ b/src/common/ChordModel/ChordLine.ts
@@ -129,6 +129,12 @@ export class ChordLine
         return lodash.omit(plainObject, "id");
     }
 
+    // for copying purposes, the section is usually not
+    // intended to be pasted elsewhere
+    forCopying(): ChordLine {
+        return this.set("section", undefined);
+    }
+
     private new(maybeNew: ChordLineRecord): ChordLine {
         if (maybeNew === this.record) {
             return this;

--- a/src/components/edit/CopyAndPaste.ts
+++ b/src/components/edit/CopyAndPaste.ts
@@ -55,8 +55,11 @@ export const deserializeCopiedChordLines = (
 };
 
 const serializeCopiedChordLines = (chordLines: List<ChordLine>): string => {
+    const copyableLines: List<ChordLine> = chordLines.map((line: ChordLine) =>
+        line.forCopying()
+    );
     const payload: CopiedChordLines = {
-        copiedChordLines: chordLines.toArray(),
+        copiedChordLines: copyableLines.toArray(),
     };
 
     return JSON.stringify(payload);


### PR DESCRIPTION
When copying and pasting lines, section labels aren't really what the user (i.e. me) is looking for, it's mostly the chord/lyric content. It's usually nontransferable, and in the case of section labels with time, it's almost never transferable.