### PR TITLE
Usability: swap transpose and speed controls

### DIFF
--- a/src/components/track_player/internal_player/ControlPane.tsx
+++ b/src/components/track_player/internal_player/ControlPane.tsx
@@ -133,7 +133,6 @@ const ControlPane: React.FC<ControlPaneProps> = (
                 />
             </ControlGroup>
             <SectionLabel value={props.sectionLabel} />
-            {transposeControl}
             <ControlGroup dividers="left">
                 {[
                     <PlayrateControl
@@ -142,6 +141,7 @@ const ControlPane: React.FC<ControlPaneProps> = (
                     />,
                 ]}
             </ControlGroup>
+            {transposeControl}
         </ControlPaneBox>
     );
 };


### PR DESCRIPTION
Move the transpose control to the right side, so that it's the first to disappear - the tempo control is more likely to be used so it should disappear after the transpose, not before.