### PR TITLE
Delay checking isOnline

### DIFF
--- a/src/components/useCloud.tsx
+++ b/src/components/useCloud.tsx
@@ -93,11 +93,11 @@ export const useCloud = (): [
                     return;
                 }
 
-                if (!(await isOnline())) {
+                if (!shouldSave(newSong)) {
                     return;
                 }
 
-                if (!shouldSave(newSong)) {
+                if (!(await isOnline())) {
                     return;
                 }
 


### PR DESCRIPTION
Reordering this check - isOnline performs a network ping, but we don't actually need to do it unless the state is dirty.