### PR TITLE
Fix: Keyboard shortcuts also invoke transport control 

### DIFF
--- a/src/components/track_player/internal_player/ControlButton.tsx
+++ b/src/components/track_player/internal_player/ControlButton.tsx
@@ -40,10 +40,22 @@ const makeControlButton = (
 ): React.FC<ButtonProps> => {
     const ColoredButton = color === "primary" ? PrimaryButton : SecondaryButton;
 
+    // the keyboard usage of the player collides with any keyboard triggers of control buttons
+    // so disable them entirely, which may happen through keyups
+    const preventKeyInvocation = (
+        event: React.KeyboardEvent<HTMLButtonElement>
+    ) => {
+        event.preventDefault();
+    };
+
     return (props: ButtonProps) => (
         <Tooltip key={key} title={tooltipMsg}>
             <span>
-                <ColoredButton {...props} size="large">
+                <ColoredButton
+                    {...props}
+                    onKeyUp={preventKeyInvocation}
+                    size="large"
+                >
                     {child}
                 </ColoredButton>
             </span>


### PR DESCRIPTION
Key strokes to play/pause (spacebar) is also causing a press on the last transport button that was focused - doing a preventdefault there so that no surprises happen.