### PR TITLE
Allow option/alt key to result in copy drop

### DIFF
--- a/src/components/edit/DragAndDrop.tsx
+++ b/src/components/edit/DragAndDrop.tsx
@@ -47,7 +47,7 @@ export const HTML5BackendWithCTRLKey = (
 
     untypesafeBackend.handleTopDragEnter = (e: DragEvent) => {
         untypesafeBackend.__original__handleTopDragEnter?.(e);
-        untypesafeBackend.altKeyPressed = e.ctrlKey || e.metaKey;
+        untypesafeBackend.altKeyPressed = e.ctrlKey || e.metaKey || e.altKey;
     };
 
     if (
@@ -61,7 +61,7 @@ export const HTML5BackendWithCTRLKey = (
         untypesafeBackend.handleTopDragOver;
     untypesafeBackend.handleTopDragOver = (e: DragEvent) => {
         untypesafeBackend.__original__handleTopDragOver?.(e);
-        untypesafeBackend.altKeyPressed = e.ctrlKey || e.metaKey;
+        untypesafeBackend.altKeyPressed = e.ctrlKey || e.metaKey || e.altKey;
     };
 
     return backend;

--- a/src/components/tutorial/DragAndDropChord.tsx
+++ b/src/components/tutorial/DragAndDropChord.tsx
@@ -54,8 +54,8 @@ const DragAndDropChord: React.FC<{}> = (): JSX.Element => {
             </Typography>
             <LineBreak />
             <Typography>
-                If you hold CTRL or CMD while dragging and dropping, the chord
-                will be copied instead of moved over.
+                If you hold CTRL/CMD/ALT/Option while dragging and dropping, the
+                chord will be copied instead of moved over.
             </Typography>
             <LineBreak />
             <Typography>


### PR DESCRIPTION
Support Option/Alt also for the copy chord drop. When holding option on macos at least, the little copy plus icon will be adorned, so we should at least follow the visual cue.