### PR TITLE
ControlPane styling improvements

### DIFF
--- a/src/components/track_player/internal_player/ControlGroup.tsx
+++ b/src/components/track_player/internal_player/ControlGroup.tsx
@@ -1,5 +1,5 @@
 import { Box, Divider, Theme } from "@material-ui/core";
-import { withStyles } from "@material-ui/styles";
+import { StyledComponentProps, withStyles } from "@material-ui/styles";
 import React from "react";
 
 export const ControlGroupBox = withStyles({
@@ -20,9 +20,10 @@ export const VerticalMiddleDivider = withStyles((theme: Theme) => ({
     },
 }))(Divider);
 
-interface ControlGroupProps {
+interface ControlGroupProps extends StyledComponentProps {
     children: React.ReactNode[];
     dividers: "left" | "right";
+    edgeDivider?: boolean;
 }
 
 const ControlGroup: React.FC<ControlGroupProps> = (
@@ -36,6 +37,15 @@ const ControlGroup: React.FC<ControlGroupProps> = (
 
     const contents: React.ReactElement[] = realContents.map(
         (child: React.ReactNode, index: number) => {
+            const isEdge =
+                (props.dividers === "left" && index === 0) ||
+                (props.dividers === "right" &&
+                    index === realContents.length - 1);
+
+            if (props.edgeDivider !== true && isEdge) {
+                return <React.Fragment key={index}>{child}</React.Fragment>;
+            }
+
             const divider = (
                 <VerticalMiddleDivider
                     key={`divider-${index}`}
@@ -53,7 +63,9 @@ const ControlGroup: React.FC<ControlGroupProps> = (
         }
     );
 
-    return <ControlGroupBox>{contents}</ControlGroupBox>;
+    return (
+        <ControlGroupBox classes={props.classes}>{contents}</ControlGroupBox>
+    );
 };
 
 export default ControlGroup;

--- a/src/components/track_player/internal_player/ControlPane.tsx
+++ b/src/components/track_player/internal_player/ControlPane.tsx
@@ -31,6 +31,12 @@ interface ControlPaneProps {
     sectionLabel: string;
 }
 
+const RightJustifiedControlGroup = withStyles({
+    root: {
+        marginLeft: "auto",
+    },
+})(ControlGroup);
+
 export const ControlPaneBox = withStyles((theme: Theme) => {
     const buttonHeight = theme.spacing(5);
     return {
@@ -105,7 +111,7 @@ const ControlPane: React.FC<ControlPaneProps> = (
         }
 
         return (
-            <ControlGroup dividers="left">
+            <ControlGroup dividers="left" edgeDivider>
                 {[
                     <TransposeControl
                         transposeLevel={props.transpose.level}
@@ -133,14 +139,14 @@ const ControlPane: React.FC<ControlPaneProps> = (
                 />
             </ControlGroup>
             <SectionLabel value={props.sectionLabel} />
-            <ControlGroup dividers="left">
+            <RightJustifiedControlGroup dividers="left">
                 {[
                     <PlayrateControl
                         playratePercentage={props.playrate.percentage}
                         onChange={props.playrate.onChange}
                     />,
                 ]}
-            </ControlGroup>
+            </RightJustifiedControlGroup>
             {transposeControl}
         </ControlPaneBox>
     );


### PR DESCRIPTION
Making this thing look better
-removing the edge dividers on the transport controls and the playrate controls
-pushing the playrate + transposition controls all the way to the right. if given enough space, the playrate controls used to wander to the middle