### PR TITLE
Undo/Redo functionality

### DIFF
--- a/src/components/edit/BatchDelete.ts
+++ b/src/components/edit/BatchDelete.ts
@@ -1,23 +1,32 @@
 import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { IDable } from "../../common/ChordModel/Collection";
+import { ChordSongAction } from "../reducer/reducer";
 import { getSelectedLineIDs } from "./LineSelection";
 
 export const handleBatchLineDelete = (
-    event: React.KeyboardEvent<HTMLDivElement>
-): false | IDable<ChordLine>[] => {
+    event: React.KeyboardEvent<HTMLDivElement>,
+    songDispatch: React.Dispatch<ChordSongAction>
+): boolean => {
     if (event.key !== "Backspace") {
         return false;
     }
 
-    const lineIDs: string[] = getSelectedLineIDs();
-    if (lineIDs.length === 0) {
+    const lineIDStrs: string[] = getSelectedLineIDs();
+    if (lineIDStrs.length === 0) {
         return false;
     }
 
-    event.preventDefault();
+    const lineIDs = lineIDStrs.map(
+        (id: string): IDable<ChordLine> => ({
+            type: "ChordLine",
+            id: id,
+        })
+    );
 
-    return lineIDs.map((id: string) => ({
-        type: "ChordLine",
-        id: id,
-    }));
+    songDispatch({
+        type: "batch-remove-lines",
+        lineIDs: lineIDs,
+    });
+
+    return true;
 };

--- a/src/components/edit/Undo.ts
+++ b/src/components/edit/Undo.ts
@@ -1,0 +1,19 @@
+import { ChordSongAction } from "../reducer/reducer";
+
+export const handleUndoRedo = (
+    event: React.KeyboardEvent<HTMLDivElement>,
+    songDispatch: React.Dispatch<ChordSongAction>
+): boolean => {
+    const isSpecialKey = event.metaKey || event.ctrlKey;
+    if (event.key !== "z" || !isSpecialKey) {
+        return false;
+    }
+
+    if (event.shiftKey) {
+        songDispatch({ type: "redo" });
+    } else {
+        songDispatch({ type: "undo" });
+    }
+
+    return true;
+};

--- a/src/components/reducer/reducer.ts
+++ b/src/components/reducer/reducer.ts
@@ -1,3 +1,4 @@
+import { List, Record } from "immutable";
 import { useCallback, useReducer } from "react";
 import { ChordBlock } from "../../common/ChordModel/ChordBlock";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
@@ -9,6 +10,14 @@ import { Note } from "../../common/music/foundation/Note";
 type ReplaceSong = {
     type: "replace-song";
     newSong: ChordSong;
+};
+
+type Undo = {
+    type: "undo";
+};
+
+type Redo = {
+    type: "redo";
 };
 
 type SetHeader = {
@@ -106,6 +115,8 @@ type SetSection = {
 
 export type ChordSongAction =
     | ReplaceSong
+    | Undo
+    | Redo
     | SetHeader
     | SetLastSavedAt
     | AddLine
@@ -122,9 +133,90 @@ export type ChordSongAction =
     | SetSection
     | Transpose;
 
+export type ChordSongActionWithoutUndo = Exclude<ChordSongAction, Undo | Redo>;
+
+type ChordSongStackType = {
+    undoStack: List<ChordSong>;
+    currentSongIndex: number;
+};
+
+const ChordSongStackConstructor = Record<ChordSongStackType>({
+    undoStack: List(),
+    currentSongIndex: -1,
+});
+
+type ChordSongStack = ReturnType<typeof ChordSongStackConstructor>;
+
+const getCurrentSong = (state: ChordSongStack): ChordSong => {
+    const currentSong: ChordSong | undefined = state.undoStack.get(
+        state.currentSongIndex
+    );
+
+    if (currentSong === undefined) {
+        throw new Error(
+            "Invalid state: no valid entry found in undo stack for current state"
+        );
+    }
+
+    return currentSong;
+};
+
+// the separation between these two reducer functions is that
+// most operations don't need to understand then undo stack, only
+// undo and redo operations require it, so splitting these keeps each
+// easier to manage
 const chordSongReducer = (
-    song: ChordSong,
+    state: ChordSongStack,
     action: ChordSongAction
+): ChordSongStack => {
+    switch (action.type) {
+        case "undo": {
+            if (state.currentSongIndex === 0) {
+                return state;
+            }
+
+            state = state.update("currentSongIndex", (index) => index - 1);
+            return state;
+        }
+
+        case "redo": {
+            const lastIndex = state.undoStack.size - 1;
+
+            if (state.currentSongIndex === lastIndex) {
+                return state;
+            }
+
+            state = state.update("currentSongIndex", (index) => index + 1);
+            return state;
+        }
+
+        default: {
+            const currentSong = getCurrentSong(state);
+            const newSong = chordSongReducerWithoutUndo(currentSong, action);
+            const currentSongIndex = state.currentSongIndex;
+
+            const blowAwayRedoStack = (
+                list: List<ChordSong>
+            ): List<ChordSong> => {
+                return list.slice(0, currentSongIndex + 1);
+            };
+
+            state = state.update("undoStack", (list) => {
+                list = blowAwayRedoStack(list);
+                list = list.push(newSong);
+                return list;
+            });
+
+            state = state.update("currentSongIndex", (index) => index + 1);
+
+            return state;
+        }
+    }
+};
+
+const chordSongReducerWithoutUndo = (
+    song: ChordSong,
+    action: ChordSongActionWithoutUndo
 ): ChordSong => {
     switch (action.type) {
         case "replace-song": {
@@ -335,14 +427,28 @@ export const useChordSongReducer = (
     onChange?: (newSong: ChordSong, action: ChordSongAction) => void
 ): [ChordSong, React.Dispatch<ChordSongAction>] => {
     const reducerWithChangeCallback = useCallback(
-        (song: ChordSong, action: ChordSongAction): ChordSong => {
-            const newSong: ChordSong = chordSongReducer(song, action);
+        (state: ChordSongStack, action: ChordSongAction): ChordSongStack => {
+            const newState = chordSongReducer(state, action);
+            const newSong = getCurrentSong(state);
+
             onChange?.(newSong, action);
 
-            return newSong;
+            return newState;
         },
         [onChange]
     );
 
-    return useReducer(reducerWithChangeCallback, initialSong);
+    const initialState = ChordSongStackConstructor({
+        undoStack: List([initialSong]),
+        currentSongIndex: 0,
+    });
+
+    const [state, dispatch] = useReducer(
+        reducerWithChangeCallback,
+        initialState
+    );
+
+    const currentSong = getCurrentSong(state);
+
+    return [currentSong, dispatch];
 };


### PR DESCRIPTION
Adding undo and redo to all operations. Since iterative copies of the song are now much more performant, we can just store them all in a list and move a pointer up and down the list.

CMD/CTRL + Z = undo
SHIFT + CMD/CTRL + Z = redo