### PR TITLE
Move body key handlers to global

### DIFF
--- a/src/components/edit/BatchDelete.ts
+++ b/src/components/edit/BatchDelete.ts
@@ -4,7 +4,7 @@ import { ChordSongAction } from "../reducer/reducer";
 import { getSelectedLineIDs } from "./LineSelection";
 
 export const handleBatchLineDelete = (
-    event: React.KeyboardEvent<HTMLDivElement>,
+    event: KeyboardEvent,
     songDispatch: React.Dispatch<ChordSongAction>
 ): boolean => {
     if (event.key !== "Backspace") {

--- a/src/components/edit/Undo.ts
+++ b/src/components/edit/Undo.ts
@@ -1,7 +1,7 @@
 import { ChordSongAction } from "../reducer/reducer";
 
 export const handleUndoRedo = (
-    event: React.KeyboardEvent<HTMLDivElement>,
+    event: KeyboardEvent,
     songDispatch: React.Dispatch<ChordSongAction>
 ): boolean => {
     const isSpecialKey = event.metaKey || event.ctrlKey;


### PR DESCRIPTION
Right now, keys for the body only work when it's focused on the paper body, but sometimes the user is focused outside and still wants to undo. Moving it to global seems more intuitive as a user interaction.