### PR TITLE
Improve box styling on Windows

### DIFF
--- a/src/components/edit/Token.tsx
+++ b/src/components/edit/Token.tsx
@@ -21,7 +21,7 @@ const InvisibleTypography = withStyles({
         position: "absolute",
         left: 0,
         top: 0,
-        transform: "translate(0%, -115%)",
+        transform: "translate(0%, -110%)",
     },
 })(LyricTypography);
 


### PR DESCRIPTION
The chord input box gets cut off on Windows. Moving it down slightly.