### PR TITLE
Play mode: Hide scrollbars

### DIFF
--- a/src/components/play/PlayContent.tsx
+++ b/src/components/play/PlayContent.tsx
@@ -143,6 +143,9 @@ const PlayContent: React.FC<PlayContentProps> = (
         },
     })(Paper);
 
+    // removing scrollbars on Windows
+    // play mode causes scrollbars on Windows
+    // this is sort of a workaround until we can find a better CSS solution
     useEffect(() => {
         const getScrollBarWidth = (): unknown => {
             return (document.documentElement.style as any).scrollbarWidth;

--- a/src/components/play/PlayContent.tsx
+++ b/src/components/play/PlayContent.tsx
@@ -143,6 +143,22 @@ const PlayContent: React.FC<PlayContentProps> = (
         },
     })(Paper);
 
+    useEffect(() => {
+        const getScrollBarWidth = (): unknown => {
+            return (document.documentElement.style as any).scrollbarWidth;
+        };
+
+        const setScrollBarWidth = (scrollbarWidth: unknown) => {
+            (document.documentElement.style as any).scrollbarWidth =
+                scrollbarWidth;
+        };
+
+        const prevScrollbarWidthValue = getScrollBarWidth();
+        setScrollBarWidth("none");
+
+        return () => setScrollBarWidth(prevScrollbarWidthValue);
+    }, []);
+
     // using margins instead of column-gap, CSS columns force the rightmost column
     // up against the edge of the viewport and doesn't strictly respect column width
     //


### PR DESCRIPTION
On Windows, for some reason play mode causes scrollbars to render. At 100vh, it shouldn't cause scrollbars but nonetheless it does.

A better fix would be to fix the CSS on Windows such that it doesn't cause scrollbars. However, there is a firefox CSS style that can hide the scrollbars so using that for now.