### PR TITLE
Fix misaligned scrolling in play mode on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
         "react-player": "^2.8.2",
         "react-router-dom": "^5.2.0",
         "react-scripts": "3.4.1",
+        "react-scrollbar-size": "^4.0.0",
         "react-use-konami": "^1.0.13",
         "shortid": "^2.2.15",
         "svguitar": "^1.12.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -81,12 +81,14 @@ const SnackbarProvider = withStyles((theme: Theme) => ({
     },
 }))(UnstyledSnackbarProvider);
 
-const AppLayout = withStyles({
+const withBackground = withStyles({
     root: {
         backgroundImage: `url(${Background})`,
         minHeight: "100vh",
     },
-})(Grid);
+});
+
+const AppLayout = withBackground(Grid);
 
 const MainSong = withCloudSaveSongContext(SongRouter);
 
@@ -98,18 +100,24 @@ const AppContent: React.FC<{}> = (): JSX.Element => {
     const location = useLocation();
     const loadSongPath = songPath.withID(":id");
 
-    const isFullScreen =
-        SongIDModePath.isPlayMode(location.pathname) ||
-        location.pathname === guitarDemoPath.URL();
-
-    const withRegularAppLayout = (
+    const withLayout = (
         child: React.ReactElement | React.ReactElement[]
-    ) => {
+    ): React.ReactElement => {
+        if (SongIDModePath.isPlayMode(location.pathname)) {
+            // no background required on full screen play mode
+            // more importantly, don't set the min-height
+            return (
+                <Grid container>
+                    <Grid item container justify="center">
+                        {child}
+                    </Grid>
+                </Grid>
+            );
+        }
+
         return (
             <>
-                {!isFullScreen && (
-                    <SideMenu onUserChanged={handleUserChanged} />
-                )}
+                <SideMenu onUserChanged={handleUserChanged} />
                 <AppLayout container>
                     <Grid item container justify="center">
                         {child}
@@ -125,13 +133,13 @@ const AppContent: React.FC<{}> = (): JSX.Element => {
             <Redirect from={rootPath.URL()} to={newSongPath.URL()} exact />
 
             <Route key={newSongPath.URL()} path={newSongPath.URL()}>
-                {withRegularAppLayout(
+                {withLayout(
                     <MainSong song={new ChordSong({})} path={newSongPath} />
                 )}
             </Route>
 
             <Route key={loadSongPath.URL()} path={loadSongPath.URL()}>
-                {withRegularAppLayout(
+                {withLayout(
                     <SongFetcher>
                         {(song: ChordSong) => (
                             <MainSong
@@ -143,9 +151,9 @@ const AppContent: React.FC<{}> = (): JSX.Element => {
                 )}
             </Route>
 
-            {TutorialSwitches(withRegularAppLayout)}
+            {TutorialSwitches(withLayout)}
             <Route key={aboutPath.URL()} path={aboutPath.URL()} exact>
-                {withRegularAppLayout(<About />)}
+                {withLayout(<About />)}
             </Route>
             <Route key={guitarDemoPath.URL()} path={guitarDemoPath.URL()} exact>
                 <GuitarDemo />

--- a/src/components/play/PlayContent.tsx
+++ b/src/components/play/PlayContent.tsx
@@ -2,6 +2,7 @@ import { Box, Paper, RootRef } from "@material-ui/core";
 import grey from "@material-ui/core/colors/grey";
 import { withStyles } from "@material-ui/styles";
 import { useWindowWidth } from "@react-hook/window-size";
+import useScrollbarSize from "react-scrollbar-size";
 import React, { useCallback, useEffect, useState } from "react";
 import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
@@ -40,6 +41,7 @@ const PlayContent: React.FC<PlayContentProps> = (
     const windowWidth = useWindowWidth();
     const columnWidth = windowWidth / numberOfColumnsPerPage;
     const snapThreshold = columnWidth / 2;
+    const { height: scrollbarHeight } = useScrollbarSize();
 
     const scrollPage = useCallback(
         (forward: boolean) => {
@@ -131,6 +133,8 @@ const PlayContent: React.FC<PlayContentProps> = (
         event.preventDefault();
     };
 
+    const viewportHeightWithoutScrollbar = `calc(100vh - ${scrollbarHeight}px)`;
+
     const ColumnedPaper = withStyles({
         root: {
             columnGap: "0px",
@@ -138,29 +142,10 @@ const PlayContent: React.FC<PlayContentProps> = (
             columnRuleStyle: "solid",
             columnRuleColor: grey[300],
             columns: numberOfColumnsPerPage,
-            height: "100vh",
+            height: viewportHeightWithoutScrollbar,
             width: "100%",
         },
     })(Paper);
-
-    // removing scrollbars on Windows
-    // play mode causes scrollbars on Windows
-    // this is sort of a workaround until we can find a better CSS solution
-    useEffect(() => {
-        const getScrollBarWidth = (): unknown => {
-            return (document.documentElement.style as any).scrollbarWidth;
-        };
-
-        const setScrollBarWidth = (scrollbarWidth: unknown) => {
-            (document.documentElement.style as any).scrollbarWidth =
-                scrollbarWidth;
-        };
-
-        const prevScrollbarWidthValue = getScrollBarWidth();
-        setScrollBarWidth("none");
-
-        return () => setScrollBarWidth(prevScrollbarWidthValue);
-    }, []);
 
     // using margins instead of column-gap, CSS columns force the rightmost column
     // up against the edge of the viewport and doesn't strictly respect column width
@@ -179,7 +164,7 @@ const PlayContent: React.FC<PlayContentProps> = (
 
     const FullHeightBox = withStyles({
         root: {
-            height: "100vh",
+            height: viewportHeightWithoutScrollbar,
             pageBreakInside: "avoid",
         },
     })(Box);

--- a/yarn.lock
+++ b/yarn.lock
@@ -10416,6 +10416,11 @@ react-scripts@3.4.1:
   optionalDependencies:
     fsevents "2.1.2"
 
+react-scrollbar-size@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/react-scrollbar-size/-/react-scrollbar-size-4.0.0.tgz#47c130b9c46331c1bdade030b890d80388da9c6b"
+  integrity sha512-6ocQusPakZGPQQc5mxMRd9Cqy1ALKHyR6eGFbNWM94NPRBnhqAo0DSWXBodhgm9vg8y21o3ZudYJD8gyoW/NRw==
+
 react-transition-group@^4.4.0:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.1.tgz#63868f9325a38ea5ee9535d828327f85773345c9"


### PR DESCRIPTION
Issue: 
In Play mode, scrolling behaviour was unaligned to pages on Windows. This was an unintended side effect from https://github.com/veedubyou/chord-paper-fe/pull/275 . Clearly that wasn't the right fix due to it being a bandaid. It also only works in Firefox, not Chrome.

The desired state is to have no vertical scrollbars (although horizontal scrollbars is expected due to songs being usually longer than one screen) - then the scroll distance will not need to worry about scrollbar widths at all.

![image](https://user-images.githubusercontent.com/5819893/163107128-7042c429-7083-43b4-b968-9554232c5956.png)

Play mode content has height set to 100vh, but with a horizontal scrollbar, the content is hidden by the horizontal scrollbar and introduces a vertical scrollbar just to scroll the little bit occluded by the horizontal scrollbar.

This is not an issue on MacOS because the scrollbar is basically invisible until hovered over, and is overlayed into to the content itself.

Explanation here: https://codepen.io/Mamboleoo/post/scrollbars-and-css-custom-properties

Fix:
For play mode, set the content height to be 100vh - the horizontal scrollbar height. That will allow the content to extend to right above the horizontal scrollbar and leave no vertical scroll. If there's no horizontal scrollbar (in the case of a short song) then this will still work as the height will just resolve to 0.
