### PR TITLE
Tutorial page route utility

### DIFF
--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { Link, Route } from "react-router-dom";
 import ErrorPage from "./display/ErrorPage";
 import AddChord from "./tutorial/AddChord";
-import AddLine from "./tutorial/AddLine";
+import AddLineFC from "./tutorial/AddLine";
 import ChordPositioning from "./tutorial/ChordPositioning";
 import CopyAndPaste from "./tutorial/CopyAndPaste";
 import DragAndDropChord from "./tutorial/DragAndDropChord";
@@ -24,11 +24,11 @@ import Login from "./tutorial/Login";
 import RemoveMultipleLines from "./tutorial/RemoveMultipleLines";
 import TrackPlayer from "./tutorial/TrackPlayer";
 import TimeLabels from "./tutorial/TimeLabels";
+import { TutorialComponent } from "./tutorial/TutorialComponent";
 
 type ExerciseEntry = {
-    title: string;
     route: string;
-    component: React.FC<{}>;
+    component: TutorialComponent;
 };
 
 export type ExerciseRoute = {
@@ -38,102 +38,82 @@ export type ExerciseRoute = {
 
 const allExercises: ExerciseEntry[] = [
     {
-        title: "Starting",
         route: "/learn/start",
         component: Starting,
     },
     {
-        title: "Edit a Chord",
         route: "/learn/edit-chord",
         component: EditChord,
     },
     {
-        title: "Remove a Chord",
         route: "/learn/remove-chord",
         component: RemoveChord,
     },
     {
-        title: "Add a Chord",
         route: "/learn/add-chord",
         component: AddChord,
     },
     {
-        title: "Drag and Drop Chords",
         route: "/learn/drag-and-drop-chord",
         component: DragAndDropChord,
     },
     {
-        title: "Edit Lyrics",
         route: "/learn/edit-lyrics",
         component: EditLyrics,
     },
     {
-        title: "Instrumentals",
         route: "/learn/instrumentals",
         component: Instrumental,
     },
     {
-        title: "Chord Positioning",
         route: "/learn/chord-positioning",
         component: ChordPositioning,
     },
     {
-        title: "Adding New Line",
         route: "/learn/add-line",
-        component: AddLine,
+        component: AddLineFC,
     },
     {
-        title: "Removing a Line",
         route: "/learn/remove-line",
         component: RemoveLine,
     },
     {
-        title: "Pasting Lyrics",
         route: "/learn/paste-lyrics",
         component: PasteLyrics,
     },
     {
-        title: "Removing Multiple Lines",
         route: "/learn/remove-multiple-lines",
         component: RemoveMultipleLines,
     },
     {
-        title: "Merging Lines",
         route: "/learn/merge-lines",
         component: MergeLine,
     },
     {
-        title: "Splitting Lines",
         route: "/learn/split-lines",
         component: SplitLine,
     },
     {
-        title: "Copying and Pasting Lines",
         route: "/learn/copy-and-paste",
         component: CopyAndPaste,
     },
     {
-        title: "Labels",
         route: "/learn/labels",
         component: Labels,
     },
     {
-        title: "Labels with Timestamp",
         route: "/learn/time-labels",
         component: TimeLabels,
     },
     {
-        title: "Play Mode",
         route: "/learn/play-mode",
         component: PlayMode,
     },
     {
-        title: "Logging In",
         route: "/learn/login",
         component: Login,
     },
     {
-        title: "Track Player",
         route: "/learn/track-player",
         component: TrackPlayer,
     },
@@ -141,9 +121,26 @@ const allExercises: ExerciseEntry[] = [
 
 export const allExerciseRoutes = (): ExerciseRoute[] => {
     return allExercises.map((entry: ExerciseEntry) => ({
-        title: entry.title,
+        title: entry.component.title,
         route: entry.route,
     }));
+};
+
+export const getRouteForTutorialComponent = (
+    tutorialComponent: TutorialComponent
+): string => {
+    const matchingExercise: ExerciseEntry | undefined = allExercises.find(
+        (exercise: ExerciseEntry) =>
+            exercise.component.title === tutorialComponent.title
+    );
+
+    if (matchingExercise === undefined) {
+        throw new Error(
+            "Input tutorial component not found in list - is the list up to date?"
+        );
+    }
+
+    return matchingExercise.route;
 };
 
 const PlayArrowIcon = withStyles({

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { Link, Route } from "react-router-dom";
 import ErrorPage from "./display/ErrorPage";
 import AddChord from "./tutorial/AddChord";
-import AddLineFC from "./tutorial/AddLine";
+import AddLine from "./tutorial/AddLine";
 import ChordPositioning from "./tutorial/ChordPositioning";
 import CopyAndPaste from "./tutorial/CopyAndPaste";
 import DragAndDropChord from "./tutorial/DragAndDropChord";
@@ -71,7 +71,7 @@ const allExercises: ExerciseEntry[] = [
     },
     {
         route: "/learn/add-line",
-        component: AddLineFC,
+        component: AddLine,
     },
     {
         route: "/learn/remove-line",

--- a/src/components/tutorial/AddChord.tsx
+++ b/src/components/tutorial/AddChord.tsx
@@ -6,8 +6,11 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { ChordTypography, LineBreak, LyricsTypography } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
 
-const AddChord: React.FC<{}> = (): JSX.Element => {
+const title = "Add Chords";
+
+const AddChord = (): JSX.Element => {
     const initialSong = new ChordSong({
         lines: [
             new ChordLine({
@@ -40,7 +43,7 @@ const AddChord: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Adding Chords</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 Add a chord by hovering above a word, and clicking the outlined
@@ -56,4 +59,4 @@ const AddChord: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default AddChord;
+export default convertToTutorialComponent(AddChord, title);

--- a/src/components/tutorial/AddLine.tsx
+++ b/src/components/tutorial/AddLine.tsx
@@ -6,6 +6,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { LineBreak, LyricsTypography } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Add New Lines";
 
 const AddLine: React.FC<{}> = (): JSX.Element => {
     const initialSong = new ChordSong({
@@ -54,7 +57,7 @@ const AddLine: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Adding New Lines</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 You can add more lines by hovering below (or above) and existing
@@ -70,4 +73,4 @@ const AddLine: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default AddLine;
+export default convertToTutorialComponent(AddLine, title);

--- a/src/components/tutorial/ChordPositioning.tsx
+++ b/src/components/tutorial/ChordPositioning.tsx
@@ -6,6 +6,9 @@ import { ChordLine } from "../../common/ChordModel/ChordLine";
 import { ChordBlock } from "../../common/ChordModel/ChordBlock";
 import { LineBreak, LyricsTypography, ChordTypography } from "./Common";
 import { Lyric } from "../../common/ChordModel/Lyric";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Chord Positioning"
 
 const ChordPositioning: React.FC<{}> = (): JSX.Element => {
     const initialSong = new ChordSong({
@@ -71,7 +74,7 @@ const ChordPositioning: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Chord Positioning</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 Sometimes you want to emphasize a chord landing on a specific
@@ -112,4 +115,4 @@ const ChordPositioning: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default ChordPositioning;
+export default convertToTutorialComponent(ChordPositioning, title);

--- a/src/components/tutorial/CopyAndPaste.tsx
+++ b/src/components/tutorial/CopyAndPaste.tsx
@@ -6,6 +6,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { LineBreak, LyricsTypography } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Copy and Paste Lines";
 
 const CopyAndPaste: React.FC<{}> = (): JSX.Element => {
     const initialSong = new ChordSong({
@@ -232,7 +235,7 @@ const CopyAndPaste: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Copying and Pasting Lines</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 Sometimes you want to just repeat what's on the page without
@@ -284,4 +287,4 @@ const CopyAndPaste: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default CopyAndPaste;
+export default convertToTutorialComponent(CopyAndPaste, title);

--- a/src/components/tutorial/DragAndDropChord.tsx
+++ b/src/components/tutorial/DragAndDropChord.tsx
@@ -6,6 +6,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { ChordTypography, LineBreak, LyricsTypography } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Drag and Drop Chords";
 
 const DragAndDropChord: React.FC<{}> = (): JSX.Element => {
     const initialSong = new ChordSong({
@@ -44,7 +47,7 @@ const DragAndDropChord: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Dragging and Dropping Chords</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 It's also possible to drag and drop chords onto different parts
@@ -72,4 +75,4 @@ const DragAndDropChord: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default DragAndDropChord;
+export default convertToTutorialComponent(DragAndDropChord, title);

--- a/src/components/tutorial/EditChord.tsx
+++ b/src/components/tutorial/EditChord.tsx
@@ -6,6 +6,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { ChordTypography, LineBreak, LyricsTypography } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Edit Chords";
 
 const EditChord: React.FC<{}> = (): JSX.Element => {
     const initialSong = new ChordSong({
@@ -44,7 +47,7 @@ const EditChord: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Editing Chords</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 Click on a chord to change it, then press enter to commit your
@@ -60,4 +63,4 @@ const EditChord: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default EditChord;
+export default convertToTutorialComponent(EditChord, title);

--- a/src/components/tutorial/EditLyrics.tsx
+++ b/src/components/tutorial/EditLyrics.tsx
@@ -6,6 +6,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { LineBreak, LyricsTypography } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Edit Lyrics";
 
 const EditLyrics: React.FC<{}> = (): JSX.Element => {
     const initialSong = new ChordSong({
@@ -44,7 +47,7 @@ const EditLyrics: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Editing Lyrics</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 You can edit the lyrics by clicking anywhere along the lyrics.
@@ -62,4 +65,4 @@ const EditLyrics: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default EditLyrics;
+export default convertToTutorialComponent(EditLyrics, title);

--- a/src/components/tutorial/Instrumental.tsx
+++ b/src/components/tutorial/Instrumental.tsx
@@ -6,6 +6,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { ChordTypography, LineBreak, LyricsTypography } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Instrumental Sections";
 
 const Instrumental: React.FC<{}> = (): JSX.Element => {
     const tabExample = new ChordSong({
@@ -36,7 +39,7 @@ const Instrumental: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Instrumental Sections</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 In addition to putting chords over lyrics, you can also put them
@@ -82,4 +85,4 @@ const Instrumental: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default Instrumental;
+export default convertToTutorialComponent(Instrumental, title);

--- a/src/components/tutorial/Labels.tsx
+++ b/src/components/tutorial/Labels.tsx
@@ -8,6 +8,9 @@ import { Lyric } from "../../common/ChordModel/Lyric";
 import { sectionLabelStyle } from "../display/SectionLabel";
 import { LineBreak } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Labels";
 
 const LabelTypography = withStyles(sectionLabelStyle)(Typography);
 
@@ -73,7 +76,7 @@ const Labels: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Labels</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 It's common to label sections to navigate easily within the
@@ -95,4 +98,4 @@ const Labels: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default Labels;
+export default convertToTutorialComponent(Labels, title);

--- a/src/components/tutorial/Login.tsx
+++ b/src/components/tutorial/Login.tsx
@@ -2,12 +2,19 @@ import { Typography } from "@material-ui/core";
 import CloudUploadIcon from "@material-ui/icons/CloudUpload";
 import React from "react";
 import { Link } from "react-router-dom";
+import { getRouteForTutorialComponent } from "../Tutorial";
 import { LineBreak } from "./Common";
+import TrackPlayer from "./TrackPlayer";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Logging In";
 
 const Login: React.FC<{}> = (): JSX.Element => {
+    const trackPlayerRoute = getRouteForTutorialComponent(TrackPlayer);
+
     return (
         <>
-            <Typography variant="h5">Logging In</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 You can save and load your songs if you have logged in. When you
@@ -17,10 +24,9 @@ const Login: React.FC<{}> = (): JSX.Element => {
                 automatically.
             </Typography>
             <LineBreak />
-            {/*TODO: replace hard link with a reference*/}
             <Typography>
                 Having an account also means you can add music tracks to the{" "}
-                <Link to="/learn/track-player">Track Player</Link>.
+                <Link to={trackPlayerRoute}>Track Player</Link>.
             </Typography>
             <LineBreak />
             <Typography>
@@ -41,4 +47,4 @@ const Login: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default Login;
+export default convertToTutorialComponent(Login, title);

--- a/src/components/tutorial/MergeLine.tsx
+++ b/src/components/tutorial/MergeLine.tsx
@@ -6,6 +6,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { LineBreak } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Merge Lines";
 
 const MergeLine: React.FC<{}> = (): JSX.Element => {
     const initialSong = new ChordSong({
@@ -52,7 +55,7 @@ const MergeLine: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Merging Lines</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 Sometimes the lyrics that we paste in is not the division we
@@ -69,4 +72,4 @@ const MergeLine: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default MergeLine;
+export default convertToTutorialComponent(MergeLine, title);

--- a/src/components/tutorial/PasteLyrics.tsx
+++ b/src/components/tutorial/PasteLyrics.tsx
@@ -6,6 +6,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { LineBreak, LyricsTypography } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Paste Lyrics";
 
 const PasteLyrics: React.FC<{}> = (): JSX.Element => {
     const initialSong = new ChordSong({
@@ -71,7 +74,7 @@ const PasteLyrics: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Pasting Lyrics</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 It would be annoying to have to type out the lyrics. But we can
@@ -95,4 +98,4 @@ const PasteLyrics: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default PasteLyrics;
+export default convertToTutorialComponent(PasteLyrics, title);

--- a/src/components/tutorial/PlayMode.tsx
+++ b/src/components/tutorial/PlayMode.tsx
@@ -2,11 +2,14 @@ import { Typography } from "@material-ui/core";
 import PlayIcon from "@material-ui/icons/PlayArrow";
 import React from "react";
 import { LineBreak } from "./Common";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Play Mode";
 
 const PlayMode: React.FC<{}> = (): JSX.Element => {
     return (
         <>
-            <Typography variant="h5">Play Mode</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 Play mode is where you focus on playing the song rather than
@@ -33,4 +36,4 @@ const PlayMode: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default PlayMode;
+export default convertToTutorialComponent(PlayMode, title);

--- a/src/components/tutorial/RemoveChord.tsx
+++ b/src/components/tutorial/RemoveChord.tsx
@@ -6,6 +6,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { ChordTypography, LineBreak } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Remove Chords";
 
 const RemoveChord: React.FC<{}> = (): JSX.Element => {
     const initialSong = new ChordSong({
@@ -40,7 +43,7 @@ const RemoveChord: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Removing Chords</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 Simply remove all the chord text when editing to clear the
@@ -54,4 +57,4 @@ const RemoveChord: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default RemoveChord;
+export default convertToTutorialComponent(RemoveChord, title);

--- a/src/components/tutorial/RemoveLine.tsx
+++ b/src/components/tutorial/RemoveLine.tsx
@@ -8,6 +8,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { LineBreak } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Remove Lines";
 
 const BackspaceIcon = withStyles({
     root: {
@@ -62,7 +65,7 @@ const RemoveLine: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Removing Lines</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 Similarly, you can remove a line by hovering over the line, and
@@ -76,4 +79,4 @@ const RemoveLine: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default RemoveLine;
+export default convertToTutorialComponent(RemoveLine, title);

--- a/src/components/tutorial/RemoveMultipleLines.tsx
+++ b/src/components/tutorial/RemoveMultipleLines.tsx
@@ -6,6 +6,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { LineBreak } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Remove Multiple Lines";
 
 const RemoveMultipleLines: React.FC<{}> = (): JSX.Element => {
     const initialSong = new ChordSong({
@@ -82,7 +85,7 @@ const RemoveMultipleLines: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Removing Multiple Lines</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 You can remove multiple lines at once by dragging and selecting
@@ -96,4 +99,4 @@ const RemoveMultipleLines: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default RemoveMultipleLines;
+export default convertToTutorialComponent(RemoveMultipleLines, title);

--- a/src/components/tutorial/SplitLine.tsx
+++ b/src/components/tutorial/SplitLine.tsx
@@ -75,12 +75,6 @@ const SplitLine: React.FC<{}> = (): JSX.Element => {
             <Typography>(CTRL+Enter : Windows | CMD+Enter : Mac)</Typography>
             <LineBreak />
             <Typography>
-                Right now, chords won't move to the subsequent line - only
-                lyrics will. This can be worked around by dragging and dropping
-                chords after until the feature is cleaned up.
-            </Typography>
-            <LineBreak />
-            <Typography>
                 Let's break the one long line of lyrics up, so that it looks
                 like:
             </Typography>

--- a/src/components/tutorial/SplitLine.tsx
+++ b/src/components/tutorial/SplitLine.tsx
@@ -6,6 +6,9 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { Lyric } from "../../common/ChordModel/Lyric";
 import { LineBreak, LyricsTypography } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Split Lines";
 
 const SplitLine: React.FC<{}> = (): JSX.Element => {
     const initialSong = new ChordSong({
@@ -62,7 +65,7 @@ const SplitLine: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Splitting Lines</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 Similarly, we can split lines that may be too long for our chart
@@ -90,4 +93,4 @@ const SplitLine: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default SplitLine;
+export default convertToTutorialComponent(SplitLine, title);

--- a/src/components/tutorial/Start.tsx
+++ b/src/components/tutorial/Start.tsx
@@ -1,9 +1,12 @@
 import { Typography } from "@material-ui/core";
 import React from "react";
 import { LineBreak } from "./Common";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Learn Chord Paper";
 
 const Header = () => {
-    return <Typography variant="h5">Learning Chord Paper</Typography>;
+    return <Typography variant="h5">{title}</Typography>;
 };
 
 const Preamble = () => {
@@ -34,4 +37,4 @@ const Starting: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default Starting;
+export default convertToTutorialComponent(Starting, title);

--- a/src/components/tutorial/TimeLabels.tsx
+++ b/src/components/tutorial/TimeLabels.tsx
@@ -10,6 +10,9 @@ import PlayerTimeProvider, { PlayerTimeContext } from "../PlayerTimeContext";
 import { LineBreak } from "./Common";
 import Playground from "./Playground";
 import { convertToTutorialComponent } from "./TutorialComponent";
+import { getRouteForTutorialComponent } from "../Tutorial";
+import TrackPlayer from "./TrackPlayer";
+import { Link } from "react-router-dom";
 
 const title = "Labels with Timestamp";
 
@@ -89,6 +92,8 @@ const TimeLabels: React.FC<{}> = (): JSX.Element => {
         ],
     });
 
+    const trackPlayerRoute = getRouteForTutorialComponent(TrackPlayer);
+
     return (
         <>
             <Typography variant="h5">{title}</Typography>
@@ -106,15 +111,16 @@ const TimeLabels: React.FC<{}> = (): JSX.Element => {
             </Typography>
             <LineBreak />
             <Typography>
-                Alternatively, you can set the time to the current time in the
-                track player (see the Track Player tutorial) by clicking the{" "}
+                Alternatively, you can set the time to the current time in the{" "}
+                <Link to={trackPlayerRoute}>track player</Link> by clicking the{" "}
                 <SlowMotionVideoIcon /> button.
             </Typography>
             <LineBreak />
             <Typography>
                 In this example, pretend that the current verse starts at time
                 1:23 and that is the current time in the track player. Let's set
-                the time of the label to 1:23.
+                the time of the label to 1:23 by clicking the{" "}
+                <SlowMotionVideoIcon /> button.
             </Typography>
             <LineBreak />
             <Typography>Try it!</Typography>

--- a/src/components/tutorial/TimeLabels.tsx
+++ b/src/components/tutorial/TimeLabels.tsx
@@ -9,6 +9,9 @@ import { sectionLabelStyle } from "../display/SectionLabel";
 import PlayerTimeProvider, { PlayerTimeContext } from "../PlayerTimeContext";
 import { LineBreak } from "./Common";
 import Playground from "./Playground";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Labels with Timestamp";
 
 const LabelTypography = withStyles(sectionLabelStyle)(Typography);
 
@@ -88,7 +91,7 @@ const TimeLabels: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Labels with Timestamp</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 After creating a label, it's possible to annotate each section
@@ -126,4 +129,4 @@ const TimeLabels: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default TimeLabels;
+export default convertToTutorialComponent(TimeLabels, title);

--- a/src/components/tutorial/TrackPlayer.tsx
+++ b/src/components/tutorial/TrackPlayer.tsx
@@ -12,6 +12,9 @@ import StemTrackControlPane, {
 } from "../track_player/internal_player/stem/StemTrackControlPane";
 import TransposeControl from "../track_player/internal_player/TransposeControl";
 import { LineBreak } from "./Common";
+import { convertToTutorialComponent } from "./TutorialComponent";
+
+const title = "Track Player";
 
 const SmallControlPaneBox = withStyles({
     root: {
@@ -45,7 +48,7 @@ const TrackPlayer: React.FC<{}> = (): JSX.Element => {
 
     return (
         <>
-            <Typography variant="h5">Track Player</Typography>
+            <Typography variant="h5">{title}</Typography>
             <LineBreak />
             <Typography>
                 The track player is an integrated audio player which helps with
@@ -185,4 +188,4 @@ const TrackPlayer: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default TrackPlayer;
+export default convertToTutorialComponent(TrackPlayer, title);

--- a/src/components/tutorial/TutorialComponent.ts
+++ b/src/components/tutorial/TutorialComponent.ts
@@ -1,0 +1,16 @@
+import React from "react";
+
+interface TitleComponent {
+    title: string;
+}
+
+export type TutorialComponent = React.FC<{}> & TitleComponent;
+
+export const convertToTutorialComponent = (
+    fc: React.FC<{}>,
+    title: string
+): TutorialComponent => {
+    const tutorialComponent: TutorialComponent = fc as TutorialComponent;
+    tutorialComponent.title = title;
+    return tutorialComponent;
+};

--- a/src/components/user/Login.tsx
+++ b/src/components/user/Login.tsx
@@ -17,6 +17,8 @@ import { Link } from "react-router-dom";
 import SigninIcon from "../../assets/img/google_signin.svg";
 import { BackendError, RequestError } from "../../common/backend/errors";
 import { login } from "../../common/backend/requests";
+import { getRouteForTutorialComponent } from "../Tutorial";
+import LoginTutorial from "../tutorial/Login";
 import { deserializeUser, User, UserContext } from "./userContext";
 
 const Paper = withStyles({
@@ -246,6 +248,9 @@ const Login: React.FC<LoginProps> = (props: LoginProps): JSX.Element => {
 
             switch (dialogError.code) {
                 case "no_account":
+                    const loginTutorialRoute =
+                        getRouteForTutorialComponent(LoginTutorial);
+
                     return (
                         <Alert severity="info">
                             <AlertTitle>No account found</AlertTitle>
@@ -257,7 +262,7 @@ const Login: React.FC<LoginProps> = (props: LoginProps): JSX.Element => {
                                 You can still use the offline functionalities
                                 for now. You won't be able to save any songs
                                 that you write right now. See more details{" "}
-                                <Link to="/learn/login">here</Link>.
+                                <Link to={loginTutorialRoute}>here</Link>.
                             </Paragraph>
                             <Paragraph>Invite requests coming soon.</Paragraph>
                         </Alert>


### PR DESCRIPTION
Cleaning up some stuff from the last PR: the links to tutorial pages were hard linked.

Adding the ability to resolve a tutorial's link by referencing that tutorial's component.