### PR TITLE
Add throttling to scrolling in play mode

### DIFF
--- a/src/components/play/PlayContent.tsx
+++ b/src/components/play/PlayContent.tsx
@@ -9,6 +9,7 @@ import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { useRegisterKeyListener } from "../GlobalKeyListener";
 import { isScrollBackwardsKey, isScrollForwardsKey } from "./keyMap";
 import PlayLine from "./PlayLine";
+import { useThrottledCallback } from "use-debounce/lib";
 
 export interface DisplaySettings {
     numberOfColumnsPerPage: number;
@@ -79,8 +80,25 @@ const PlayContent: React.FC<PlayContentProps> = (
         ]
     );
 
-    const scrollForward = useCallback(() => scrollPage(true), [scrollPage]);
-    const scrollBackward = useCallback(() => scrollPage(false), [scrollPage]);
+    const throttleTimeInterval = 400;
+
+    const throttledScrollPage = useThrottledCallback(
+        scrollPage,
+        throttleTimeInterval,
+        {
+            leading: true,
+            trailing: false,
+        }
+    );
+
+    const scrollForward = useCallback(
+        () => throttledScrollPage(true),
+        [throttledScrollPage]
+    );
+    const scrollBackward = useCallback(
+        () => throttledScrollPage(false),
+        [throttledScrollPage]
+    );
 
     const handleClick = (
         event: React.MouseEvent<HTMLDivElement, MouseEvent>
@@ -207,7 +225,6 @@ const PlayContent: React.FC<PlayContentProps> = (
         };
 
         addKeyListener(handleKey);
-
         return () => removeKeyListener(handleKey);
     }, [scrollBackward, scrollForward, addKeyListener, removeKeyListener]);
 


### PR DESCRIPTION
Adding some throttling to the scroll behaviour in play mode - users (i.e. me) can accidentally double tap a scroll which is usually not what's desired, and then have to go back during a playthrough. This change prevents that by only allowing one scroll event in a time interval.

The time interval value might need to be fine tuned after more testing.