### PR TITLE
Centering the page load spinner

### DIFF
--- a/src/components/SongFetcher.tsx
+++ b/src/components/SongFetcher.tsx
@@ -1,4 +1,9 @@
+import { Backdrop, Modal } from "@material-ui/core";
+import Box from "@material-ui/core/Box";
 import CircularProgress from "@material-ui/core/CircularProgress";
+import { grey } from "@material-ui/core/colors";
+import { fade } from "@material-ui/core/styles/colorManipulator";
+import { withStyles } from "@material-ui/styles";
 import { isLeft } from "fp-ts/lib/These";
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
@@ -6,6 +11,22 @@ import { getSong } from "../common/backend/requests";
 import { ChordSong } from "../common/ChordModel/ChordSong";
 import { FetchState } from "../common/fetch";
 import ErrorImage from "./display/ErrorImage";
+
+const GreyishBackdrop = withStyles({
+    root: {
+        backgroundColor: fade(grey[200], 0.7),
+    },
+})(Backdrop);
+
+const FullScreenCenterBox = withStyles({
+    root: {
+        display: "flex",
+        justifyContent: "center",
+        alignItems: "center",
+        width: "100vw",
+        height: "100vh",
+    },
+})(Box);
 
 interface IDParams {
     id: string;
@@ -52,9 +73,17 @@ const InternalFetcher: React.FC<InternalFetcherProps> = (
         case "error": {
             return <ErrorImage error={fetchState.error} />;
         }
+
         case "loading": {
-            return <CircularProgress size={200} thickness={1} />;
+            return (
+                <Modal open BackdropComponent={GreyishBackdrop}>
+                    <FullScreenCenterBox>
+                        <CircularProgress size={200} thickness={2} />
+                    </FullScreenCenterBox>
+                </Modal>
+            );
         }
+
         case "loaded": {
             return props.children(fetchState.item);
         }


### PR DESCRIPTION
Making the page load spinner less ugly by centering is vertically, and adding a modal effect so the background also blurs.

Before:
![image](https://user-images.githubusercontent.com/5819893/165700024-0f4dbce5-7fdf-4c06-9dea-922154b0fcab.png)

After:
![image](https://user-images.githubusercontent.com/5819893/165699313-a67ee8a5-95fe-4f2a-85fe-4a59ad460d74.png)
