### PR TITLE
Move react-scripts into dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
         "react-helmet-async": "^1.0.6",
         "react-player": "^2.8.2",
         "react-router-dom": "^5.2.0",
-        "react-scripts": "3.4.1",
         "react-scrollbar-size": "^4.0.0",
         "react-use-konami": "^1.0.13",
         "shortid": "^2.2.15",
@@ -82,6 +81,7 @@
     "devDependencies": {
         "jest-environment-jsdom-sixteen": "^1.0.3",
         "prettier": "2.3.1",
+        "react-scripts": "3.4.1",
         "ts-jest": "^26.0.0"
     },
     "resolutions": {


### PR DESCRIPTION
In order to silence dependabot alerts that aren't real.