### PR TITLE
Assigning a URL path to Play scroll + page views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,8 +22,8 @@ import {
     aboutPath,
     guitarDemoPath,
     newSongPath,
+    PlaySongPath,
     rootPath,
-    SongIDModePath,
     songPath,
 } from "./common/paths";
 import About from "./components/about/About";
@@ -103,7 +103,7 @@ const AppContent: React.FC<{}> = (): JSX.Element => {
     const withLayout = (
         child: React.ReactElement | React.ReactElement[]
     ): React.ReactElement => {
-        if (SongIDModePath.isPlayMode(location.pathname)) {
+        if (PlaySongPath.isPlayMode(location.pathname)) {
             // no background required on full screen play mode
             // more importantly, don't set the min-height
             return (

--- a/src/common/paths.ts
+++ b/src/common/paths.ts
@@ -1,7 +1,6 @@
 // P A T H S
 // by Isayama
 
-type Mode = "edit" | "play";
 const newSongID = "new";
 
 export class RootPath {
@@ -55,8 +54,12 @@ export class SongIDPath {
         return this.id === newSongID;
     }
 
-    withMode(mode: Mode): SongIDModePath {
-        return new SongIDModePath(this.id, mode);
+    withEditMode(): EditSongPath {
+        return new EditSongPath(this.id);
+    }
+
+    withPlayMode(): PlaySongPath {
+        return new PlaySongPath(this.id, "root");
     }
 
     parent(): SongPath {
@@ -65,15 +68,51 @@ export class SongIDPath {
 }
 export const newSongPath = songPath.withNew();
 
-export class SongIDModePath {
+export class EditSongPath {
     private readonly id: string;
-    private readonly mode: Mode;
-    constructor(id: string, mode: Mode) {
+    constructor(id: string) {
+        this.id = id;
+    }
+
+    URL(): string {
+        return `/song/${this.id}/edit`;
+    }
+
+    parent(): SongIDPath {
+        return new SongIDPath(this.id);
+    }
+
+    static isEditMode(path: string): boolean {
+        const result = path.match(/\/song\/.+\/edit/i);
+        return result !== null;
+    }
+}
+
+export class PlaySongPath {
+    private readonly id: string;
+    private readonly mode: "page" | "scroll" | "root";
+
+    constructor(id: string, mode: "page" | "scroll" | "root") {
         this.id = id;
         this.mode = mode;
     }
+
     URL(): string {
-        return `/song/${this.id}/${this.mode}`;
+        const baseURL = `/song/${this.id}/play`;
+
+        if (this.mode === "root") {
+            return baseURL;
+        }
+
+        return `${baseURL}/${this.mode}`;
+    }
+
+    withPageView(): PlaySongPath {
+        return new PlaySongPath(this.id, "page");
+    }
+
+    withScrollView(): PlaySongPath {
+        return new PlaySongPath(this.id, "scroll");
     }
 
     parent(): SongIDPath {
@@ -82,11 +121,6 @@ export class SongIDModePath {
 
     static isPlayMode(path: string): boolean {
         const result = path.match(/\/song\/.+\/play/i);
-        return result !== null;
-    }
-
-    static isEditMode(path: string): boolean {
-        const result = path.match(/\/song\/.+\/edit/i);
         return result !== null;
     }
 }

--- a/src/common/test/path.test.ts
+++ b/src/common/test/path.test.ts
@@ -16,14 +16,28 @@ describe("paths", () => {
             describe("with mode", () => {
                 test("edit mode", () => {
                     expect(
-                        new SongPath().withID("id-desu").withMode("edit").URL()
+                        new SongPath().withID("id-desu").withEditMode().URL()
                     ).toEqual("/song/id-desu/edit");
                 });
 
-                test("play mode", () => {
-                    expect(
-                        new SongPath().withID("id-desu").withMode("play").URL()
-                    ).toEqual("/song/id-desu/play");
+                describe("play mode", () => {
+                    test("root of play mode", () => {
+                        expect(
+                            new SongPath().withID("id-desu").withPlayMode().URL()
+                        ).toEqual("/song/id-desu/play");    
+                    })
+
+                    test("page view", () => {
+                        expect(
+                            new SongPath().withID("id-desu").withPlayMode().withPageView().URL()
+                        ).toEqual("/song/id-desu/play/page");
+                    })
+
+                    test("scroll view", () => {
+                        expect(
+                            new SongPath().withID("id-desu").withPlayMode().withScrollView().URL()
+                        ).toEqual("/song/id-desu/play/scroll");
+                    })
                 });
             });
         });
@@ -36,14 +50,28 @@ describe("paths", () => {
             describe("with mode", () => {
                 test("edit mode", () => {
                     expect(
-                        new SongPath().withNew().withMode("edit").URL()
+                        new SongPath().withNew().withEditMode().URL()
                     ).toEqual("/song/new/edit");
                 });
 
-                test("play mode", () => {
-                    expect(
-                        new SongPath().withNew().withMode("play").URL()
-                    ).toEqual("/song/new/play");
+                describe("play mode", () => {
+                    test("root of play mode", () => {
+                        expect(
+                            new SongPath().withNew().withPlayMode().URL()
+                        ).toEqual("/song/new/play");    
+                    })
+
+                    test("page view", () => {
+                        expect(
+                            new SongPath().withNew().withPlayMode().withPageView().URL()
+                        ).toEqual("/song/new/play/page");
+                    })
+
+                    test("scroll view", () => {
+                        expect(
+                            new SongPath().withNew().withPlayMode().withScrollView().URL()
+                        ).toEqual("/song/new/play/scroll");
+                    })
                 });
             });
         });

--- a/src/components/SongRouter.tsx
+++ b/src/components/SongRouter.tsx
@@ -18,8 +18,8 @@ const SongRouter: MultiFC<SongRouterProps> = (
 ): JSX.Element[] => {
     const history = useHistory();
 
-    const editPath = props.path.withMode("edit");
-    const playPath = props.path.withMode("play");
+    const editPath = props.path.withEditMode();
+    const playPath = props.path.withPlayMode();
 
     const switchToEdit = () => {
         history.push(editPath.URL());
@@ -41,7 +41,7 @@ const SongRouter: MultiFC<SongRouterProps> = (
             />
         </Route>,
         <Route key={playPath.URL()} path={playPath.URL()}>
-            <Play song={props.song} onEditMode={switchToEdit} />
+            <Play song={props.song} onEditMode={switchToEdit} path={playPath} />
         </Route>,
     ];
 };

--- a/src/components/edit/menu/cloudSave.tsx
+++ b/src/components/edit/menu/cloudSave.tsx
@@ -46,7 +46,7 @@ export const useCloudCreateSong = () => {
 
         const deserializedSong = deserializeResult.right;
         history.push(
-            songPath.withID(deserializedSong.id).withMode("edit").URL()
+            songPath.withID(deserializedSong.id).withEditMode().URL()
         );
     };
 

--- a/src/components/useCloud.tsx
+++ b/src/components/useCloud.tsx
@@ -6,7 +6,7 @@ import { Prompt, useHistory } from "react-router";
 import { RequestError, useErrorSnackbar } from "../common/backend/errors";
 import { updateSong } from "../common/backend/requests";
 import { ChordSong } from "../common/ChordModel/ChordSong";
-import { SongIDModePath } from "../common/paths";
+import { EditSongPath } from "../common/paths";
 import { ChordSongAction } from "./reducer/reducer";
 import { User, UserContext } from "./user/userContext";
 
@@ -128,7 +128,7 @@ export const useCloud = (): [
         const showLeavingPrompt = () => {
             if (
                 shouldSave(song) &&
-                SongIDModePath.isEditMode(history.location.pathname)
+                EditSongPath.isEditMode(history.location.pathname)
             ) {
                 return "This page is asking you to confirm that you want to leave - data you have entered may not be saved.";
             }


### PR DESCRIPTION
Giving Play scroll view and Play page view a URL path instead of toggling on component state, this allows the user to refresh the page without switching views unexpectedly.