### PR TITLE
refactored layout + routes

### DIFF
--- a/src/common/paths.ts
+++ b/src/common/paths.ts
@@ -7,23 +7,34 @@ export class RootPath {
     URL(): string {
         return "/";
     }
+
+    static readonly root: RootPath = new RootPath();
+    static rootURL(): string {
+        return this.root.URL();
+    }
 }
-export const rootPath = new RootPath();
 
 export class AboutPath {
     URL(): string {
         return "/about";
     }
+
+    static readonly root: AboutPath = new AboutPath();
+    static rootURL(): string {
+        return this.root.URL();
+    }
 }
-export const aboutPath = new AboutPath();
 
 export class GuitarDemoPath {
     URL(): string {
         return "/guitar-demo";
     }
-}
 
-export const guitarDemoPath = new GuitarDemoPath();
+    static readonly root: GuitarDemoPath = new GuitarDemoPath();
+    static rootURL(): string {
+        return this.root.URL();
+    }
+}
 
 export class SongPath {
     URL(): string {
@@ -37,8 +48,16 @@ export class SongPath {
     withNew(): SongIDPath {
         return new SongIDPath(newSongID);
     }
+
+    static readonly root: SongPath = new SongPath();
+    static rootURL(): string {
+        return this.root.URL();
+    }
+
+    static newURL(): string {
+        return this.root.withNew().URL();
+    }
 }
-export const songPath = new SongPath();
 
 export class SongIDPath {
     private readonly id: string;
@@ -46,6 +65,7 @@ export class SongIDPath {
     constructor(id: string) {
         this.id = id;
     }
+
     URL(): string {
         return `/song/${this.id}`;
     }
@@ -63,10 +83,9 @@ export class SongIDPath {
     }
 
     parent(): SongPath {
-        return songPath;
+        return SongPath.root;
     }
 }
-export const newSongPath = songPath.withNew();
 
 export class EditSongPath {
     private readonly id: string;
@@ -132,5 +151,30 @@ export class DemoPath {
 
         return new SongIDPath(neverGonnaGiveYouPlasticLoveUUID).URL();
     }
+
+    static readonly root: DemoPath = new DemoPath();
+    static rootURL(): string {
+        return this.root.URL();
+    }
 }
-export const demoPath = new DemoPath();
+
+export class TutorialPath {
+    private readonly lesson: string;
+
+    URL(): string {
+        if (this.lesson === "root") {
+            return "/learn";
+        }
+
+        return `/learn/${this.lesson}`;
+    }
+
+    constructor(lesson: string) {
+        this.lesson = lesson;
+    }
+
+    static readonly root: TutorialPath = new TutorialPath("root");
+    static rootURL(): string {
+        return this.root.URL();
+    }
+}

--- a/src/components/LoadSongDialog.tsx
+++ b/src/components/LoadSongDialog.tsx
@@ -15,7 +15,7 @@ import { useHistory } from "react-router-dom";
 import { getSongsForUser } from "../common/backend/requests";
 import { SongSummary } from "../common/ChordModel/ChordSong";
 import { FetchState } from "../common/fetch";
-import { songPath } from "../common/paths";
+import { SongPath } from "../common/paths";
 import { PlainFn } from "../common/PlainFn";
 import ErrorImage from "./display/ErrorImage";
 import { UserContext } from "./user/userContext";
@@ -88,7 +88,7 @@ const LoadSongDialog: React.FC<LoadSongsDialogProps> = (
     };
 
     const summaryListItem = (summary: SongSummary): React.ReactElement => {
-        const songLink = songPath.withID(summary.id);
+        const songLink = SongPath.root.withID(summary.id);
 
         const navigateToSong = () => {
             history.push(songLink.URL());

--- a/src/components/SideMenu.tsx
+++ b/src/components/SideMenu.tsx
@@ -24,11 +24,11 @@ import StoreIcon from "@material-ui/icons/Store";
 import { makeStyles, withStyles } from "@material-ui/styles";
 import React, { useState } from "react";
 import { Link } from "react-router-dom";
-import { demoPath, songPath } from "../common/paths";
+import { DemoPath, SongPath } from "../common/paths";
 import LoadSongDialog from "./LoadSongDialog";
 import { allExerciseRoutes, ExerciseRoute } from "./Tutorial";
 import Login from "./user/Login";
-import { User, UserContext } from "./user/userContext";
+import { SetUserContext, UserContext } from "./user/userContext";
 
 const withPointerStyle = withStyles({
     root: {
@@ -84,14 +84,10 @@ const useFillerStyle = makeStyles({
     },
 });
 
-interface SideMenuProps {
-    onUserChanged: (user: User | null) => void;
-}
-
-const SideMenu: React.FC<SideMenuProps> = (
-    props: SideMenuProps
-): JSX.Element => {
+const SideMenu: React.FC<{}> = (): JSX.Element => {
     const user = React.useContext(UserContext);
+    const onUserChanged = React.useContext(SetUserContext);
+
     const [expanded, setExpanded] = useState(false);
     const [showLoadSongsDialog, setShowLoadSongsDialog] = useState(false);
 
@@ -187,8 +183,8 @@ const SideMenu: React.FC<SideMenuProps> = (
             <Divider />
             <List>
                 <Link
-                    key={songPath.URL()}
-                    to={songPath.URL()}
+                    key={SongPath.rootURL()}
+                    to={SongPath.rootURL()}
                     style={linkStyle}
                     data-testid="Menu-HomeButton"
                 >
@@ -220,8 +216,8 @@ const SideMenu: React.FC<SideMenuProps> = (
                     </ListItem>
                 )}
                 <Link
-                    key={demoPath.URL()}
-                    to={demoPath.URL()}
+                    key={DemoPath.rootURL()}
+                    to={DemoPath.rootURL()}
                     style={linkStyle}
                     data-testid="Menu-DemoButton"
                 >
@@ -254,7 +250,7 @@ const SideMenu: React.FC<SideMenuProps> = (
                 </Link>
             </List>
             <div className={fillerStyle.root} />
-            <Login onUserChanged={props.onUserChanged} />
+            <Login onUserChanged={onUserChanged} />
         </Drawer>
     );
 

--- a/src/components/SongFetcher.tsx
+++ b/src/components/SongFetcher.tsx
@@ -11,6 +11,7 @@ import { getSong } from "../common/backend/requests";
 import { ChordSong } from "../common/ChordModel/ChordSong";
 import { FetchState } from "../common/fetch";
 import ErrorImage from "./display/ErrorImage";
+import CenteredLayoutWithMenu from "./display/CenteredLayoutWithMenu";
 
 const GreyishBackdrop = withStyles({
     root: {
@@ -36,6 +37,18 @@ interface InternalFetcherProps {
     id: string;
     children: (song: ChordSong) => JSX.Element;
 }
+
+export const FullScreenLoading: React.FC<{}> = (): JSX.Element => {
+    return (
+        <CenteredLayoutWithMenu>
+            <Modal open BackdropComponent={GreyishBackdrop}>
+                <FullScreenCenterBox>
+                    <CircularProgress size={200} thickness={2} />
+                </FullScreenCenterBox>
+            </Modal>
+        </CenteredLayoutWithMenu>
+    );
+};
 
 const InternalFetcher: React.FC<InternalFetcherProps> = (
     props: InternalFetcherProps
@@ -75,13 +88,7 @@ const InternalFetcher: React.FC<InternalFetcherProps> = (
         }
 
         case "loading": {
-            return (
-                <Modal open BackdropComponent={GreyishBackdrop}>
-                    <FullScreenCenterBox>
-                        <CircularProgress size={200} thickness={2} />
-                    </FullScreenCenterBox>
-                </Modal>
-            );
+            return <FullScreenLoading />;
         }
 
         case "loaded": {

--- a/src/components/SongRouter.tsx
+++ b/src/components/SongRouter.tsx
@@ -3,8 +3,8 @@ import { Redirect, Route, useHistory } from "react-router-dom";
 import { ChordSong } from "../common/ChordModel/ChordSong";
 import { MultiFC, transformToFC } from "../common/FunctionalComponent";
 import { SongIDPath } from "../common/paths";
-import ChordPaper from "./edit/ChordPaper";
-import Play from "./play/Play";
+import ChordPaperScreen from "./edit/ChordPaper";
+import PlayRoutes from "./play/Play";
 import { ChordSongAction } from "./reducer/reducer";
 
 interface SongRouterProps {
@@ -34,14 +34,18 @@ const SongRouter: MultiFC<SongRouterProps> = (
             <Redirect to={editPath.URL()} />,
         </Route>,
         <Route key={editPath.URL()} path={editPath.URL()}>
-            <ChordPaper
+            <ChordPaperScreen
                 song={props.song}
                 songDispatch={props.songDispatch}
                 onPlay={switchToPlay}
             />
         </Route>,
         <Route key={playPath.URL()} path={playPath.URL()}>
-            <Play song={props.song} onEditMode={switchToEdit} path={playPath} />
+            <PlayRoutes
+                song={props.song}
+                onEditMode={switchToEdit}
+                path={playPath}
+            />
         </Route>,
     ];
 };

--- a/src/components/Tutorial.tsx
+++ b/src/components/Tutorial.tsx
@@ -3,6 +3,9 @@ import UnstyledPlayArrowIcon from "@material-ui/icons/PlayArrow";
 import { withStyles } from "@material-ui/styles";
 import React from "react";
 import { Link, Route } from "react-router-dom";
+import { MultiFC, transformToFC } from "../common/FunctionalComponent";
+import { TutorialPath } from "../common/paths";
+import CenteredLayoutWithMenu from "./display/CenteredLayoutWithMenu";
 import ErrorPage from "./display/ErrorPage";
 import AddChord from "./tutorial/AddChord";
 import AddLine from "./tutorial/AddLine";
@@ -12,18 +15,18 @@ import DragAndDropChord from "./tutorial/DragAndDropChord";
 import EditChord from "./tutorial/EditChord";
 import EditLyrics from "./tutorial/EditLyrics";
 import Instrumental from "./tutorial/Instrumental";
+import Labels from "./tutorial/Labels";
+import Login from "./tutorial/Login";
 import MergeLine from "./tutorial/MergeLine";
 import PasteLyrics from "./tutorial/PasteLyrics";
+import PlayMode from "./tutorial/PlayMode";
 import RemoveChord from "./tutorial/RemoveChord";
 import RemoveLine from "./tutorial/RemoveLine";
-import Starting from "./tutorial/Start";
-import Labels from "./tutorial/Labels";
-import PlayMode from "./tutorial/PlayMode";
-import SplitLine from "./tutorial/SplitLine";
-import Login from "./tutorial/Login";
 import RemoveMultipleLines from "./tutorial/RemoveMultipleLines";
-import TrackPlayer from "./tutorial/TrackPlayer";
+import SplitLine from "./tutorial/SplitLine";
+import Starting from "./tutorial/Start";
 import TimeLabels from "./tutorial/TimeLabels";
+import TrackPlayer from "./tutorial/TrackPlayer";
 import { TutorialComponent } from "./tutorial/TutorialComponent";
 
 type ExerciseEntry = {
@@ -38,83 +41,85 @@ export type ExerciseRoute = {
 
 const allExercises: ExerciseEntry[] = [
     {
-        route: "/learn/start",
+        route: new TutorialPath("start").URL(),
         component: Starting,
     },
     {
-        route: "/learn/edit-chord",
+        route: new TutorialPath("edit-chord").URL(),
         component: EditChord,
     },
     {
-        route: "/learn/remove-chord",
+        route: new TutorialPath("remove-chord").URL(),
         component: RemoveChord,
     },
     {
-        route: "/learn/add-chord",
+        route: new TutorialPath("add-chord").URL(),
         component: AddChord,
     },
     {
-        route: "/learn/drag-and-drop-chord",
+        route: new TutorialPath("drag-and-drop-chord").URL(),
         component: DragAndDropChord,
     },
     {
-        route: "/learn/edit-lyrics",
+        route: new TutorialPath("edit-lyrics").URL(),
         component: EditLyrics,
     },
     {
-        route: "/learn/instrumentals",
+        route: new TutorialPath("instrumentals").URL(),
         component: Instrumental,
     },
     {
-        route: "/learn/chord-positioning",
+        route: new TutorialPath("chord-positioning").URL(),
         component: ChordPositioning,
     },
     {
-        route: "/learn/add-line",
+        route: new TutorialPath("add-line").URL(),
         component: AddLine,
     },
     {
-        route: "/learn/remove-line",
+        route: new TutorialPath("remove-line").URL(),
         component: RemoveLine,
     },
     {
-        route: "/learn/paste-lyrics",
+        route: new TutorialPath("paste-lyrics").URL(),
         component: PasteLyrics,
     },
     {
-        route: "/learn/remove-multiple-lines",
+        route: new TutorialPath("remove-multiple-lines").URL(),
         component: RemoveMultipleLines,
     },
     {
-        route: "/learn/merge-lines",
+        route: new TutorialPath("merge-lines").URL(),
         component: MergeLine,
     },
     {
-        route: "/learn/split-lines",
+        route: new TutorialPath("split-lines").URL(),
         component: SplitLine,
     },
     {
-        route: "/learn/copy-and-paste",
+        route: new TutorialPath("copy-and-paste").URL(),
         component: CopyAndPaste,
     },
     {
-        route: "/learn/labels",
+        route: new TutorialPath("labels").URL(),
         component: Labels,
     },
     {
-        route: "/learn/time-labels",
+        route: new TutorialPath("time-labels").URL(),
         component: TimeLabels,
     },
     {
-        route: "/learn/play-mode",
+        route: new TutorialPath("play-mode").URL(),
+
         component: PlayMode,
     },
     {
-        route: "/learn/login",
+        route: new TutorialPath("login").URL(),
+
         component: Login,
     },
     {
-        route: "/learn/track-player",
+        route: new TutorialPath("track-player").URL(),
         component: TrackPlayer,
     },
 ];
@@ -168,24 +173,22 @@ const Fab = withStyles((theme: Theme) => ({
     },
 }))(UnstyledFab);
 
-interface TutorialProps {
+interface SingleTutorialProps {
     route: string;
 }
 
-type WrapperFn = (child: React.ReactElement) => React.ReactElement;
-
-export const TutorialSwitches = (
-    wrapperFn: WrapperFn
-): React.ReactElement[] => {
-    return allExercises.map((exerciseEntry: ExerciseEntry) => (
-        <Route key={exerciseEntry.route} exact path={exerciseEntry.route}>
-            {wrapperFn(<Tutorial route={exerciseEntry.route} />)}
-        </Route>
-    ));
+const SingleTutorialScreen: React.FC<SingleTutorialProps> = (
+    props: SingleTutorialProps
+): JSX.Element => {
+    return (
+        <CenteredLayoutWithMenu>
+            <SingleTutorial route={props.route} />
+        </CenteredLayoutWithMenu>
+    );
 };
 
-const Tutorial: React.FC<TutorialProps> = (
-    props: TutorialProps
+const SingleTutorial: React.FC<SingleTutorialProps> = (
+    props: SingleTutorialProps
 ): JSX.Element => {
     const matchEntry = (entry: ExerciseEntry): boolean => {
         return entry.route === props.route;
@@ -220,3 +223,13 @@ const Tutorial: React.FC<TutorialProps> = (
         </RootPaper>
     );
 };
+
+const TutorialRoutes: MultiFC<{}> = (): React.ReactElement[] => {
+    return allExercises.map((exerciseEntry: ExerciseEntry) => (
+        <Route key={exerciseEntry.route} path={exerciseEntry.route} exact>
+            <SingleTutorialScreen route={exerciseEntry.route} />
+        </Route>
+    ));
+};
+
+export default transformToFC(TutorialRoutes);

--- a/src/components/about/About.tsx
+++ b/src/components/about/About.tsx
@@ -2,6 +2,7 @@ import { Grid, Paper, Theme, Typography } from "@material-ui/core";
 import { withStyles } from "@material-ui/styles";
 import React from "react";
 import { inflatingWhitespace } from "../../common/Whitespace";
+import CenteredLayoutWithMenu from "../display/CenteredLayoutWithMenu";
 
 const RootPaper = withStyles((theme: Theme) => ({
     root: {
@@ -62,4 +63,12 @@ const About: React.FC<{}> = (): JSX.Element => {
     );
 };
 
-export default About;
+const AboutScreen: React.FC<{}> = (): JSX.Element => {
+    return (
+        <CenteredLayoutWithMenu>
+            <About />
+        </CenteredLayoutWithMenu>
+    );
+};
+
+export default AboutScreen;

--- a/src/components/display/CenteredLayout.tsx
+++ b/src/components/display/CenteredLayout.tsx
@@ -1,0 +1,20 @@
+import { Grid } from "@material-ui/core";
+import React from "react";
+
+interface CenteredLayoutProps {
+    children: React.ReactNode | React.ReactNode[];
+}
+
+const CenteredLayout: React.FC<CenteredLayoutProps> = (
+    props: CenteredLayoutProps
+): JSX.Element => {
+    return (
+        <Grid container>
+            <Grid item container justify="center">
+                {props.children}
+            </Grid>
+        </Grid>
+    );
+};
+
+export default CenteredLayout;

--- a/src/components/display/CenteredLayoutWithMenu.tsx
+++ b/src/components/display/CenteredLayoutWithMenu.tsx
@@ -1,0 +1,35 @@
+import { Grid } from "@material-ui/core";
+import { withStyles } from "@material-ui/styles";
+import React from "react";
+import SideMenu from "../SideMenu";
+import Version from "../Version";
+import Background from "../../assets/img/symphony.png";
+
+const AppLayout = withStyles({
+    root: {
+        backgroundImage: `url(${Background})`,
+        minHeight: "100vh",
+    },
+})(Grid);
+
+interface CenteredLayoutWithMenuProps {
+    children: React.ReactNode | React.ReactNode[];
+}
+
+const CenteredLayoutWithMenu: React.FC<CenteredLayoutWithMenuProps> = (
+    props: CenteredLayoutWithMenuProps
+): JSX.Element => {
+    return (
+        <>
+            <SideMenu />
+            <AppLayout container>
+                <Grid item container justify="center">
+                    {props.children}
+                </Grid>
+            </AppLayout>
+            <Version />
+        </>
+    );
+};
+
+export default CenteredLayoutWithMenu;

--- a/src/components/edit/ChordPaper.tsx
+++ b/src/components/edit/ChordPaper.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { Helmet } from "react-helmet-async";
 import { ChordSong } from "../../common/ChordModel/ChordSong";
 import { PlainFn } from "../../common/PlainFn";
+import CenteredLayoutWithMenu from "../display/CenteredLayoutWithMenu";
 import PlayerTimeProvider from "../PlayerTimeContext";
 import { ChordSongAction } from "../reducer/reducer";
 import JamStation from "../track_player/JamStation";
@@ -95,4 +96,14 @@ const ChordPaper: React.FC<ChordPaperProps> = (
     );
 };
 
-export default ChordPaper;
+const ChordPaperScreen: React.FC<ChordPaperProps> = (
+    props: ChordPaperProps
+): JSX.Element => {
+    return (
+        <CenteredLayoutWithMenu>
+            <ChordPaper {...props} />
+        </CenteredLayoutWithMenu>
+    );
+};
+
+export default ChordPaperScreen;

--- a/src/components/edit/menu/cloudSave.tsx
+++ b/src/components/edit/menu/cloudSave.tsx
@@ -13,7 +13,7 @@ import { useHistory } from "react-router-dom";
 import { useErrorSnackbar } from "../../../common/backend/errors";
 import { createSong, deleteSong } from "../../../common/backend/requests";
 import { ChordSong } from "../../../common/ChordModel/ChordSong";
-import { newSongPath, songPath } from "../../../common/paths";
+import { SongPath } from "../../../common/paths";
 import { noopFn, PlainFn } from "../../../common/PlainFn";
 import { User } from "../../user/userContext";
 
@@ -45,9 +45,10 @@ export const useCloudCreateSong = () => {
         }
 
         const deserializedSong = deserializeResult.right;
-        history.push(
-            songPath.withID(deserializedSong.id).withEditMode().URL()
-        );
+        const pathWithID = SongPath.root.withID(deserializedSong.id);
+        const editPath = pathWithID.withEditMode();
+
+        history.push(editPath.URL());
     };
 
     return async (song: ChordSong, user: User) => {
@@ -97,7 +98,7 @@ export const useCloudDeleteSongDialog = (
         enqueueSnackbar("Song has been successfully deleted", {
             variant: "success",
         });
-        history.push(newSongPath.URL());
+        history.push(SongPath.newURL());
     };
 
     const deleteDialog = (

--- a/src/components/user/userContext.ts
+++ b/src/components/user/userContext.ts
@@ -1,4 +1,5 @@
 import React from "react";
+import { noopFn } from "../../common/PlainFn";
 
 interface LoginResponse {
     id: string;
@@ -38,7 +39,9 @@ export class User {
     }
 }
 
+export type SetUserFn = (user: User | null) => void;
 export const UserContext = React.createContext<User | null>(null);
+export const SetUserContext = React.createContext<SetUserFn>(noopFn);
 
 export const deserializeUser = (
     response: unknown,

--- a/src/test/common.tsx
+++ b/src/test/common.tsx
@@ -2,11 +2,13 @@ import { createMuiTheme, ThemeProvider } from "@material-ui/core";
 import { SnackbarProvider } from "notistack";
 import React from "react";
 import { HelmetProvider } from "react-helmet-async";
+import { HashRouter } from "react-router-dom";
 import { ChordSong } from "../common/ChordModel/ChordSong";
 import { Lyric } from "../common/ChordModel/Lyric";
+import { noopFn } from "../common/PlainFn";
 import ChordPaper from "../components/edit/ChordPaper";
 import DragAndDrop from "../components/edit/DragAndDrop";
-import { UserContext } from "../components/user/userContext";
+import { SetUserContext, UserContext } from "../components/user/userContext";
 import { withSongContext } from "../components/WithSongContext";
 
 const Song = withSongContext(ChordPaper);
@@ -14,13 +16,17 @@ const Song = withSongContext(ChordPaper);
 export const withProviders = (children: React.ReactNode) => {
     return (
         <UserContext.Provider value={null}>
-            <HelmetProvider>
-                <ThemeProvider theme={createMuiTheme()}>
-                    <DragAndDrop>
-                        <SnackbarProvider>{children}</SnackbarProvider>
-                    </DragAndDrop>
-                </ThemeProvider>
-            </HelmetProvider>
+            <SetUserContext.Provider value={noopFn}>
+                <HelmetProvider>
+                    <ThemeProvider theme={createMuiTheme()}>
+                        <HashRouter>
+                            <DragAndDrop>
+                                <SnackbarProvider>{children}</SnackbarProvider>
+                            </DragAndDrop>
+                        </HashRouter>
+                    </ThemeProvider>
+                </HelmetProvider>
+            </SetUserContext.Provider>
         </UserContext.Provider>
     );
 };


### PR DESCRIPTION
A biggish refactor for how to insert page wide layouts on the component tree.

The motivation for this change was due to a change that happened some PRs ago where state and contexts were lost due to layout changes - layout changes shouldn't affect any functionality, yet if the layout changes they could cause a dismount of components below it and cause a functional difference.

The change: initially App.tsx held all the dirtiness in determining who gets what sort of layout, but trying to push this responsibility a bit lower. Each major section now has a respective "screen" component, which sets up the page wide layout. This seems be in the component tree right below the routing, and there may be some opportunity there for combining them in the future.

