### PR TITLE
Play Scroll View: 3 colour rotation for highlighting borders

### DIFF
--- a/src/components/play/scroll/HighlightBorderBox.tsx
+++ b/src/components/play/scroll/HighlightBorderBox.tsx
@@ -1,6 +1,7 @@
 import { Box, Theme } from "@material-ui/core";
-import { makeStyles, withStyles } from "@material-ui/styles";
+import { withStyles } from "@material-ui/styles";
 import React from "react";
+import { makeHighlightColours } from "./highlightColourContext";
 
 const transitionFunction = "cubic-bezier(.19,1,.22,1)";
 
@@ -14,11 +15,7 @@ const BorderedBox = withStyles((theme: Theme) => ({
     },
 }))(Box);
 
-const useHighlightedBorder = makeStyles((theme: Theme) => ({
-    root: {
-        borderColor: theme.palette.primary.main,
-    },
-}));
+const useHighlightBorder = makeHighlightColours();
 
 interface HighlightBorderBoxProps {
     highlight?: boolean;
@@ -28,7 +25,8 @@ interface HighlightBorderBoxProps {
 const HighlightBorderBox: React.FC<HighlightBorderBoxProps> = (
     props: HighlightBorderBoxProps
 ): JSX.Element => {
-    const highlightBorderStyle = useHighlightedBorder();
+    const highlightBorderStyle = useHighlightBorder();
+
     const highlightClassName: string | undefined = (() => {
         if (props.highlight === true) {
             return highlightBorderStyle.root;

--- a/src/components/play/scroll/HighlightBorderBox.tsx
+++ b/src/components/play/scroll/HighlightBorderBox.tsx
@@ -1,7 +1,7 @@
 import { Box, Theme } from "@material-ui/core";
 import { withStyles } from "@material-ui/styles";
 import React from "react";
-import { makeHighlightColours } from "./highlightColourContext";
+import { makeHighlightBorders } from "./highlightBorderContext";
 
 const transitionFunction = "cubic-bezier(.19,1,.22,1)";
 
@@ -15,7 +15,7 @@ const BorderedBox = withStyles((theme: Theme) => ({
     },
 }))(Box);
 
-const useHighlightBorder = makeHighlightColours();
+const useHighlightBorder = makeHighlightBorders();
 
 interface HighlightBorderBoxProps {
     highlight?: boolean;

--- a/src/components/play/scroll/ScrollPlayContent.tsx
+++ b/src/components/play/scroll/ScrollPlayContent.tsx
@@ -9,6 +9,7 @@ import { Collection } from "../../../common/ChordModel/Collection";
 import { PlainFn } from "../../../common/PlainFn";
 import FocusedElement from "../common/FocusedElement";
 import { useNavigationKeys } from "../common/useNavigateKeys";
+import { HighlightColourProvider } from "./highlightColourContext";
 import ScrollablePlayLine from "./ScrollablePlayLine";
 
 const FullHeightBox = withStyles({
@@ -199,10 +200,12 @@ const ScrollPlayContent: React.FC<ScrollPlayContentProps> = (
 
     return (
         <FocusedElement>
-            <Box>
-                {playLines}
-                <FullHeightBox />
-            </Box>
+            <HighlightColourProvider>
+                <Box>
+                    {playLines}
+                    <FullHeightBox />
+                </Box>
+            </HighlightColourProvider>
         </FocusedElement>
     );
 };

--- a/src/components/play/scroll/ScrollPlayContent.tsx
+++ b/src/components/play/scroll/ScrollPlayContent.tsx
@@ -9,7 +9,7 @@ import { Collection } from "../../../common/ChordModel/Collection";
 import { PlainFn } from "../../../common/PlainFn";
 import FocusedElement from "../common/FocusedElement";
 import { useNavigationKeys } from "../common/useNavigateKeys";
-import { HighlightColourProvider } from "./highlightColourContext";
+import { HighlightColourProvider } from "./highlightBorderContext";
 import ScrollablePlayLine from "./ScrollablePlayLine";
 
 const FullHeightBox = withStyles({

--- a/src/components/play/scroll/highlightBorderContext.tsx
+++ b/src/components/play/scroll/highlightBorderContext.tsx
@@ -16,7 +16,7 @@ const rotateColourDebounceTime = 300;
 // that still contrasts with blue and purple
 const redColor = "#ff9679";
 
-const HighlightColourContext = React.createContext<() => HighlightColour>(
+const HighlightBorderContext = React.createContext<() => HighlightColour>(
     () => "red"
 );
 
@@ -30,10 +30,10 @@ type MakeHighlightColoursMapType = {
     red: ReturnType<typeof makeStyles>;
 };
 
-const useHighlightColours = (
+const useHighlightBorders = (
     colourMap: MakeHighlightColoursMapType
 ): ClassNameMap<"root"> => {
-    const getAndRotateCurrentColour = React.useContext(HighlightColourContext);
+    const getAndRotateCurrentColour = React.useContext(HighlightBorderContext);
     const currentColour = getAndRotateCurrentColour();
 
     const highlightColourStyles = {
@@ -47,7 +47,7 @@ const useHighlightColours = (
 
 type useRootStyleType = () => ClassNameMap<"root">;
 
-export const makeHighlightColours = (): useRootStyleType => {
+export const makeHighlightBorders = (): useRootStyleType => {
     const useHighlightColoursMap: MakeHighlightColoursMapType = {
         blue: makeStyles((theme: Theme) => ({
             root: {
@@ -66,7 +66,7 @@ export const makeHighlightColours = (): useRootStyleType => {
         })),
     };
 
-    return () => useHighlightColours(useHighlightColoursMap);
+    return () => useHighlightBorders(useHighlightColoursMap);
 };
 
 export const HighlightColourProvider: React.FC<HighlightColourProviderProps> = (
@@ -104,8 +104,8 @@ export const HighlightColourProvider: React.FC<HighlightColourProviderProps> = (
     }, [rotateColour]);
 
     return (
-        <HighlightColourContext.Provider value={getAndRotateColour}>
+        <HighlightBorderContext.Provider value={getAndRotateColour}>
             {props.children}
-        </HighlightColourContext.Provider>
+        </HighlightBorderContext.Provider>
     );
 };

--- a/src/components/play/scroll/highlightColourContext.tsx
+++ b/src/components/play/scroll/highlightColourContext.tsx
@@ -1,0 +1,111 @@
+import { Theme } from "@material-ui/core";
+import { ClassNameMap, makeStyles } from "@material-ui/styles";
+import React, { useCallback, useRef } from "react";
+import { useDebouncedCallback } from "use-debounce/lib";
+
+export type HighlightColour = "blue" | "purple" | "red";
+
+// adding a debounce interval - when scrolling multiple highlights could activate that
+// rotates the colours a lot. this debounce keeps some stability in the colour rotation
+// a more robust solution would be to time it against the time that the user recognizes
+// a new colour emerging, but that requires more understanding into how to factor in
+// the scroll time and the CSS transitions
+const rotateColourDebounceTime = 300;
+
+// a pastel-ish colour in the orange/red zone
+// that still contrasts with blue and purple
+const redColor = "#ff9679";
+
+const HighlightColourContext = React.createContext<() => HighlightColour>(
+    () => "red"
+);
+
+interface HighlightColourProviderProps {
+    children: React.ReactNode | React.ReactNode[];
+}
+
+type MakeHighlightColoursMapType = {
+    blue: ReturnType<typeof makeStyles>;
+    purple: ReturnType<typeof makeStyles>;
+    red: ReturnType<typeof makeStyles>;
+};
+
+const useHighlightColours = (
+    colourMap: MakeHighlightColoursMapType
+): ClassNameMap<"root"> => {
+    const getAndRotateCurrentColour = React.useContext(HighlightColourContext);
+    const currentColour = getAndRotateCurrentColour();
+
+    const highlightColourStyles = {
+        blue: colourMap["blue"]({}),
+        purple: colourMap["purple"]({}),
+        red: colourMap["red"]({}),
+    };
+
+    return highlightColourStyles[currentColour];
+};
+
+type useRootStyleType = () => ClassNameMap<"root">;
+
+export const makeHighlightColours = (): useRootStyleType => {
+    const useHighlightColoursMap: MakeHighlightColoursMapType = {
+        blue: makeStyles((theme: Theme) => ({
+            root: {
+                borderColor: theme.palette.primary.main,
+            },
+        })),
+        purple: makeStyles((theme: Theme) => ({
+            root: {
+                borderColor: theme.palette.secondary.main,
+            },
+        })),
+        red: makeStyles((theme: Theme) => ({
+            root: {
+                borderColor: redColor,
+            },
+        })),
+    };
+
+    return () => useHighlightColours(useHighlightColoursMap);
+};
+
+export const HighlightColourProvider: React.FC<HighlightColourProviderProps> = (
+    props: HighlightColourProviderProps
+): JSX.Element => {
+    const currentColourRef = useRef<HighlightColour>("red");
+
+    const rotateColour = useDebouncedCallback(
+        () => {
+            switch (currentColourRef.current) {
+                case "blue": {
+                    currentColourRef.current = "purple";
+                    break;
+                }
+
+                case "purple": {
+                    currentColourRef.current = "red";
+                    break;
+                }
+
+                case "red": {
+                    currentColourRef.current = "blue";
+                    break;
+                }
+            }
+        },
+        rotateColourDebounceTime,
+        { leading: false, trailing: true }
+    );
+
+    const getAndRotateColour = useCallback((): HighlightColour => {
+        const currentColour = currentColourRef.current;
+        rotateColour();
+        return currentColour;
+    }, [rotateColour]);
+
+    return (
+        <HighlightColourContext.Provider value={getAndRotateColour}>
+            {props.children}
+        </HighlightColourContext.Provider>
+    );
+};


### PR DESCRIPTION
Trying a new visual design, rotating the colours of the highlight so that it gives more of a visual cue to the user that the newly highlighted line is different than the one just highlighted (and is fading).

This implementation adds a context on top which will keep cycling the colours each time one is fetched.

![image](https://user-images.githubusercontent.com/5819893/168347919-82d1a324-f097-4097-9380-82ba8fe050f5.png)
![image](https://user-images.githubusercontent.com/5819893/168347981-19ba44ab-a031-4a0d-9b71-9625e2c7dd12.png)
![image](https://user-images.githubusercontent.com/5819893/168348022-78f53ef2-3756-4df6-9ee2-2f52ffe7d9da.png)
