### PR TITLE
Fix line controls occluding track player

### DIFF
--- a/src/components/track_player/common.tsx
+++ b/src/components/track_player/common.tsx
@@ -67,14 +67,23 @@ export const widthOfString = (
 
 export const greyTextColour = grey[700];
 
-const BottomRightBox = withStyles((theme: Theme) => ({
-    root: {
-        position: "fixed",
-        bottom: 0,
-        right: theme.spacing(2),
-        ...roundedTopCornersStyle(theme),
-    },
-}))(Box);
+const BottomRightBox = withStyles((theme: Theme) => {
+    // a bit arbitrary, but the player components should come on top of the
+    // line hover menu which is powered by tooltip
+    // this could also be 9999, it's just not well understood yet
+    // if this should always be on top or if it should just be above tooltips
+    const zIndex = theme.zIndex.tooltip + 100;
+
+    return {
+        root: {
+            position: "fixed",
+            bottom: 0,
+            right: theme.spacing(2),
+            zIndex: zIndex,
+            ...roundedTopCornersStyle(theme),
+        },
+    };
+})(Box);
 
 export const withBottomRightBox = (children: React.ReactElement) => (
     <BottomRightBox boxShadow={4}>{children}</BottomRightBox>


### PR DESCRIPTION
Fixing an unsightly bug:

![image](https://user-images.githubusercontent.com/5819893/168411606-43325e15-3069-444c-b714-c22932ef056a.png)

If the track player is up but the user is hovering over a line, the tool tip hover controls can show up over the track player, which makes no sense visually.

Fix here is to give the track player a higher z-index than the hover menu. TBD if this is the right fix.