### PR TITLE
Fix tracklist selector hidden by player component in Chrome

### DIFF
--- a/src/components/track_player/JamStation.tsx
+++ b/src/components/track_player/JamStation.tsx
@@ -1,3 +1,5 @@
+import { createMuiTheme, Theme } from "@material-ui/core";
+import { ThemeProvider } from "@material-ui/styles";
 import { List } from "immutable";
 import React, { useCallback, useState } from "react";
 import shortid from "shortid";
@@ -24,6 +26,24 @@ interface TrackEditDialogState {
     open: boolean;
     randomID: string;
 }
+
+const onTopTheme = (theme: Theme): Theme => {
+    const highestZIndex = theme.zIndex.tooltip;
+    const zIndexBoost = highestZIndex + 1;
+
+    return createMuiTheme({
+        ...theme,
+        zIndex: {
+            mobileStepper: zIndexBoost + theme.zIndex.mobileStepper,
+            speedDial: zIndexBoost + theme.zIndex.speedDial,
+            appBar: zIndexBoost + theme.zIndex.appBar,
+            drawer: zIndexBoost + theme.zIndex.drawer,
+            modal: zIndexBoost + theme.zIndex.modal,
+            snackbar: zIndexBoost + theme.zIndex.snackbar,
+            tooltip: zIndexBoost + theme.zIndex.tooltip,
+        },
+    });
+};
 
 const JamStation: React.FC<JamStationProps> = (
     props: JamStationProps
@@ -126,11 +146,11 @@ const JamStation: React.FC<JamStationProps> = (
     );
 
     return (
-        <>
+        <ThemeProvider theme={onTopTheme}>
             {collapsedButtonFn(false, showPlayer, "Show Player")}
             {fullPlayer}
             {trackEditDialog}
-        </>
+        </ThemeProvider>
     );
 };
 

--- a/src/components/track_player/JamStation.tsx
+++ b/src/components/track_player/JamStation.tsx
@@ -1,10 +1,12 @@
 import { createMuiTheme, Theme } from "@material-ui/core";
+import { ZIndex } from "@material-ui/core/styles/zIndex";
 import { ThemeProvider } from "@material-ui/styles";
 import { List } from "immutable";
 import React, { useCallback, useState } from "react";
 import shortid from "shortid";
 import { TimeSection } from "../../common/ChordModel/ChordLine";
 import { TrackList } from "../../common/ChordModel/tracks/TrackList";
+import { mapObject } from "../../common/mapObject";
 import { PlainFn } from "../../common/PlainFn";
 import TrackListEditDialog from "./dialog/TrackListEditDialog";
 import { usePlayerControls } from "./internal_player/usePlayerControls";
@@ -31,17 +33,14 @@ const onTopTheme = (theme: Theme): Theme => {
     const highestZIndex = theme.zIndex.tooltip;
     const zIndexBoost = highestZIndex + 1;
 
+    const newZIndex: ZIndex = mapObject(
+        theme.zIndex,
+        (oldZIndex: number) => oldZIndex + zIndexBoost
+    );
+
     return createMuiTheme({
         ...theme,
-        zIndex: {
-            mobileStepper: zIndexBoost + theme.zIndex.mobileStepper,
-            speedDial: zIndexBoost + theme.zIndex.speedDial,
-            appBar: zIndexBoost + theme.zIndex.appBar,
-            drawer: zIndexBoost + theme.zIndex.drawer,
-            modal: zIndexBoost + theme.zIndex.modal,
-            snackbar: zIndexBoost + theme.zIndex.snackbar,
-            tooltip: zIndexBoost + theme.zIndex.tooltip,
-        },
+        zIndex: newZIndex,
     });
 };
 

--- a/src/components/track_player/common.tsx
+++ b/src/components/track_player/common.tsx
@@ -68,18 +68,14 @@ export const widthOfString = (
 export const greyTextColour = grey[700];
 
 const BottomRightBox = withStyles((theme: Theme) => {
-    // a bit arbitrary, but the player components should come on top of the
-    // line hover menu which is powered by tooltip
-    // this could also be 9999, it's just not well understood yet
-    // if this should always be on top or if it should just be above tooltips
-    const zIndex = theme.zIndex.tooltip + 100;
+    const lowestPlayerZIndex = theme.zIndex.mobileStepper;
 
     return {
         root: {
             position: "fixed",
             bottom: 0,
             right: theme.spacing(2),
-            zIndex: zIndex,
+            zIndex: lowestPlayerZIndex,
             ...roundedTopCornersStyle(theme),
         },
     };


### PR DESCRIPTION
Fixing the sketchy fix of https://github.com/veedubyou/chord-paper-fe/pull/318

Interestingly enough, the issue only happens on Chrome and not Firefox. After boosting just the z index of the player, some components such as the select menu for the track selector gets drawn behind the player instead of in front.

Fix here is to modify the theme for the track player portion such that all components below will inherit a boosted z index, and so components like the Select for the track list selector will have a higher z index than the player component, but the player component will still have a higher z index than the editing controls.