### PR TITLE
Prevent track player shifting right on select menu focus

### DIFF
--- a/src/components/track_player/MultiTrackPlayer.tsx
+++ b/src/components/track_player/MultiTrackPlayer.tsx
@@ -150,6 +150,7 @@ const MultiTrackPlayer: React.FC<MultiTrackPlayerProps> = (
                     sx={paddingLeftStyle}
                     value={props.currentTrackIndex}
                     onChange={trackChangeHandler}
+                    MenuProps={{ disableScrollLock: true }}
                 >
                     {items}
                 </Select>


### PR DESCRIPTION
This is a Material UI issue. Just a workaround for now, hopefully it's stable.

The issue:
Looking normal:
![image](https://user-images.githubusercontent.com/5819893/170850001-e7c0c619-18a8-40e1-a5fe-b4971b092b7a.png)

When the select menu is focused and the entire player shifts some amount to the right because the scrollbar disappeared:
![image](https://user-images.githubusercontent.com/5819893/170850014-a0837261-4cad-48d8-9bf9-0be2b52afc1c.png)
