### PR TITLE
Perf Regression: Scroll View

### DIFF
--- a/src/components/play/common/PlayLine.tsx
+++ b/src/components/play/common/PlayLine.tsx
@@ -49,4 +49,4 @@ const PlayLine: React.FC<PlayLineProps> = (
     return lineComponent;
 };
 
-export default PlayLine;
+export default React.memo(PlayLine);


### PR DESCRIPTION
Fixing one of a few perf regressions as part of something that was broke in the MUI5 upgrade.

In the play scroll view, there's an entire rerender of the page's contents whenever the highlight changes, because of the callback functions that get created fresh and tunneled down. These really don't need to be brand new functions for setting the ref methods, so I attached them as methods on the ViewportLine object itself in the beginning to avoid unnecessary rerenders.