### PR TITLE
Rename deployment action steps

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,4 +1,4 @@
-name: Deploy To Production
+name: Deploy Production to thatmight.work
 
 on:
     push:
@@ -44,19 +44,3 @@ jobs:
                   config: ${{ secrets.KUBE_CONFIG_DATA }}
                   version: v1.19.3
                   command: set image --record deploy/chord-fe chord-fe=${{ secrets.DOCKERHUB_USERNAME }}/chord:${{ env.gitver }}
-                  
-#            - name: Setup GCloud CLI
-#              uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
-#              with:
-#                  version: "270.0.0"
-#                  service_account_email: ${{ secrets.GKE_EMAIL }}
-#                  service_account_key: ${{ secrets.GKE_KEY }}
-
-#            - name: Deploy to GKE
-#              continue-on-error: true
-#              timeout-minutes: 2
-#              run: |
-#                  gcloud container clusters get-credentials $GKE_CLUSTER --zone $GKE_ZONE --project $GKE_PROJECT
-#                  kubectl rollout restart deploy/chord-fe
-#                  kubectl rollout status deploy/chord-fe
-#                  kubectl get services -o wide

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -1,4 +1,4 @@
-name: Publish to Github Pages
+name: Deploy Production to Github Pages
 
 on:
     push:
@@ -29,7 +29,7 @@ jobs:
             - name: Build
               run: REACT_APP_VERSION=${{ env.gitver }} yarn build-github-pages
 
-            - name: GitHub Pages action
+            - name: Push to GitHub Pages
               uses: peaceiris/actions-gh-pages@v3.6.1
               with:
                   github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Renaming the github runner actions for deployment. Right now the app deploys to two hosts, but their actions are vague (deploy to production, but which host?) and inconsistent (deploy vs publish). Amending the names so that it's clearer what's happening.