### PR TITLE
Fix transpose menu labels

### DIFF
--- a/src/components/edit/menu/TransposeMenu.tsx
+++ b/src/components/edit/menu/TransposeMenu.tsx
@@ -1,5 +1,4 @@
 import {
-    Box,
     Button,
     Dialog,
     DialogActions,

--- a/src/components/edit/menu/TransposeMenu.tsx
+++ b/src/components/edit/menu/TransposeMenu.tsx
@@ -6,10 +6,11 @@ import {
     DialogTitle,
     FormControl as UnstyledFormControl,
     FormHelperText,
-    Grid, MenuItem,
+    Grid,
+    MenuItem,
     Select as UnstyledSelect,
     SelectChangeEvent,
-    styled
+    styled,
 } from "@mui/material";
 import { ChordSong } from "common/ChordModel/ChordSong";
 import { AllNotes, Note } from "common/music/foundation/Note";

--- a/src/components/edit/menu/TransposeMenu.tsx
+++ b/src/components/edit/menu/TransposeMenu.tsx
@@ -1,13 +1,13 @@
 import {
+    Box,
     Button,
     Dialog,
     DialogActions,
     DialogContent,
     DialogTitle,
     FormControl as UnstyledFormControl,
-    Grid,
-    InputLabel,
-    MenuItem,
+    FormHelperText,
+    Grid, MenuItem,
     Select as UnstyledSelect,
     SelectChangeEvent,
     styled
@@ -69,7 +69,6 @@ const TransposeMenu: React.FC<TransposeMenuProps> = (
     };
 
     const createKeySelect = (
-        id: string,
         currentKey: Note,
         changeHandler: (event: SelectChangeEvent<unknown>) => void
     ) => {
@@ -80,7 +79,7 @@ const TransposeMenu: React.FC<TransposeMenuProps> = (
         }
 
         return (
-            <Select id={id} value={currentKey} onChange={changeHandler}>
+            <Select value={currentKey} onChange={changeHandler}>
                 {menuItems}
             </Select>
         );
@@ -93,26 +92,20 @@ const TransposeMenu: React.FC<TransposeMenuProps> = (
                 <Grid container direction="row">
                     <Grid item>
                         <FormControl>
-                            <InputLabel htmlFor="original-key">
-                                Original Key
-                            </InputLabel>
                             {createKeySelect(
-                                "original-key",
                                 keySelection.originalKey,
                                 keySelectChangeHandler("originalKey")
                             )}
+                            <FormHelperText>Original Key</FormHelperText>
                         </FormControl>
                     </Grid>
                     <Grid item>
                         <FormControl>
-                            <InputLabel htmlFor="transposed-key">
-                                Transposed Key
-                            </InputLabel>
                             {createKeySelect(
-                                "transposed-key",
                                 keySelection.transposedKey,
                                 keySelectChangeHandler("transposedKey")
                             )}
+                            <FormHelperText>Transposed Key</FormHelperText>
                         </FormControl>
                     </Grid>
                 </Grid>


### PR DESCRIPTION
MUI 5 somehow broke the labels for these select fields in the transpose menu (they would cut off at the length of the select component instead of causing the select component to lengthen). Instead of trying to figure out how to fix it I opted to use another form of input labels that looked even better.