### PR TITLE
Section highlighting

### DIFF
--- a/src/common/ChordModel/ChordLine.ts
+++ b/src/common/ChordModel/ChordLine.ts
@@ -8,7 +8,11 @@ import {
     ChordBlockValidator,
 } from "common/ChordModel/ChordBlock";
 import { replaceChordLineLyrics } from "common/ChordModel/ChordLinePatcher";
-import { Collection, CollectionMethods, IDable } from "common/ChordModel/Collection";
+import {
+    Collection,
+    CollectionMethods,
+    IDable,
+} from "common/ChordModel/Collection";
 import { Lyric } from "common/ChordModel/Lyric";
 import { List, Record } from "immutable";
 
@@ -22,7 +26,7 @@ const LabelSectionValidator = iots.type({
     name: iots.string,
 });
 
-const TimeSectionValidator = iots.type({
+const TimestampedSectionValidator = iots.type({
     type: iots.literal("time"),
     name: iots.string,
     time: iots.number,
@@ -30,7 +34,7 @@ const TimeSectionValidator = iots.type({
 
 const SectionValidator = iots.union([
     LabelSectionValidator,
-    TimeSectionValidator,
+    TimestampedSectionValidator,
 ]);
 
 const optionalFields = iots.partial({
@@ -43,12 +47,23 @@ export const ChordLineValidator = iots.intersection([
     optionalFields,
 ]);
 
-export type LabelSection = iots.TypeOf<typeof LabelSectionValidator>;
-export type TimeSection = iots.TypeOf<typeof TimeSectionValidator>;
+type LineIDForSection = { lineID: string };
+
+export type LabelSection = iots.TypeOf<typeof LabelSectionValidator> &
+    LineIDForSection;
+
+export type TimestampedSection = iots.TypeOf<
+    typeof TimestampedSectionValidator
+> &
+    LineIDForSection;
+
 export type Section = iots.TypeOf<typeof SectionValidator>;
 export type ChordLineValidatedFields = iots.TypeOf<typeof ChordLineValidator>;
 
-export const timeSectionSortFn = (a: TimeSection, b: TimeSection): number => {
+export const timestampedSectionSortFn = (
+    a: TimestampedSection,
+    b: TimestampedSection
+): number => {
     if (a.time < b.time) {
         return -1;
     }

--- a/src/common/ChordModel/Section.ts
+++ b/src/common/ChordModel/Section.ts
@@ -1,0 +1,42 @@
+import { TimestampedSection } from "common/ChordModel/ChordLine";
+import { List } from "immutable";
+
+export interface TimestampedSectionItem {
+    index: number;
+    timestampedSection: TimestampedSection;
+}
+
+export const findSectionAtTime = (
+    timestampedSections: List<TimestampedSection>,
+    currentTime: number
+): TimestampedSectionItem | null => {
+    if (timestampedSections.size === 0) {
+        return null;
+    }
+
+    let sectionItemAtCurrentTime: TimestampedSectionItem | null = null;
+
+    timestampedSections.forEach(
+        (candidateSection: TimestampedSection, index: number) => {
+            if (currentTime < candidateSection.time) {
+                return;
+            }
+
+            if (
+                sectionItemAtCurrentTime !== null &&
+                candidateSection.time <=
+                    sectionItemAtCurrentTime.timestampedSection.time
+            ) {
+                return;
+            }
+
+            sectionItemAtCurrentTime = {
+                index: index,
+                timestampedSection: candidateSection,
+            };
+        }
+    );
+
+    return sectionItemAtCurrentTime;
+};
+

--- a/src/components/PlayerSectionContext.tsx
+++ b/src/components/PlayerSectionContext.tsx
@@ -1,0 +1,58 @@
+import { ChordSong } from "common/ChordModel/ChordSong";
+import { findSectionAtTime } from "common/ChordModel/Section";
+import { PlayerTimeContext } from "components/PlayerTimeContext";
+import React, { useContext, useEffect, useState } from "react";
+
+export const PlayerSectionContext = React.createContext<string>("");
+
+interface PlayerSectionProviderProps {
+    song: ChordSong;
+    children: React.ReactNode;
+}
+
+const PlayerSectionProvider: React.FC<PlayerSectionProviderProps> = (
+    props: PlayerSectionProviderProps
+) => {
+    const getPlayerTimeRef = useContext(PlayerTimeContext);
+    const [currentSectionID, setCurrentSectionID] = useState("");
+
+    useEffect(() => {
+        const maybeSetNewSectionID = () => {
+            const getPlayerTime = getPlayerTimeRef.current;
+            if (getPlayerTime === null) {
+                return;
+            }
+
+            const currentTime = getPlayerTime();
+            const timestampedSections = props.song.timestampedSections;
+
+            const nowTimestampedSection = findSectionAtTime(
+                timestampedSections,
+                currentTime
+            );
+
+            const nowSectionID =
+                nowTimestampedSection?.timestampedSection.lineID ?? "";
+
+            const sectionChanged = nowSectionID !== currentSectionID;
+            if (!sectionChanged) {
+                return;
+            }
+
+            setCurrentSectionID(nowSectionID);
+        };
+
+        const intervalID = setInterval(maybeSetNewSectionID, 1000);
+
+        return () => clearInterval(intervalID);
+    }, [props.song, currentSectionID, getPlayerTimeRef]);
+
+    return (
+        <PlayerSectionContext.Provider value={currentSectionID}>
+            {props.children}
+        </PlayerSectionContext.Provider>
+    );
+};
+
+export default PlayerSectionProvider;
+

--- a/src/components/edit/ChordPaper.tsx
+++ b/src/components/edit/ChordPaper.tsx
@@ -6,12 +6,13 @@ import ChordPaperBody from "components/edit/ChordPaperBody";
 import Header from "components/edit/Header";
 import ChordPaperMenu from "components/edit/menu/ChordPaperMenu";
 import LoadingRender from "components/loading/LoadingRender";
+import PlayerSectionProvider from "components/PlayerSectionContext";
 import PlayerTimeProvider from "components/PlayerTimeContext";
 import { ChordSongAction } from "components/reducer/reducer";
 import JamStation from "components/track_player/JamStation";
 import TrackListProvider, {
     TrackListChangeHandler,
-    TrackListLoad
+    TrackListLoad,
 } from "components/track_player/providers/TrackListProvider";
 import React from "react";
 import { Helmet } from "react-helmet-async";
@@ -48,7 +49,7 @@ const ChordPaper: React.FC<ChordPaperProps> = (
                         collapsedButtonSx={{
                             backgroundColor: "white",
                         }}
-                        timeSections={props.song.timeSections}
+                        timestampedSections={props.song.timestampedSections}
                         tracklistLoad={tracklistLoad}
                         onTrackListChanged={changeHandler}
                         onRefresh={onRefresh}
@@ -60,30 +61,32 @@ const ChordPaper: React.FC<ChordPaperProps> = (
 
     return (
         <PlayerTimeProvider>
-            <Helmet>
-                <title>
-                    {props.song.metadata.title !== ""
-                        ? props.song.metadata.title
-                        : "New Song"}
-                </title>
-            </Helmet>
-            <RootPaper elevation={3} data-testid="ChordPaper">
-                <Header
-                    data-testid={"Header"}
-                    song={props.song}
-                    songDispatch={props.songDispatch}
-                />
-                <ChordPaperBody
-                    song={props.song}
-                    songDispatch={props.songDispatch}
-                />
-                <ChordPaperMenu
-                    song={props.song}
-                    songDispatch={props.songDispatch}
-                    onPlay={props.onPlay}
-                />
-                {trackPlayer}
-            </RootPaper>
+            <PlayerSectionProvider song={props.song}>
+                <Helmet>
+                    <title>
+                        {props.song.metadata.title !== ""
+                            ? props.song.metadata.title
+                            : "New Song"}
+                    </title>
+                </Helmet>
+                <RootPaper elevation={3} data-testid="ChordPaper">
+                    <Header
+                        data-testid={"Header"}
+                        song={props.song}
+                        songDispatch={props.songDispatch}
+                    />
+                    <ChordPaperBody
+                        song={props.song}
+                        songDispatch={props.songDispatch}
+                    />
+                    <ChordPaperMenu
+                        song={props.song}
+                        songDispatch={props.songDispatch}
+                        onPlay={props.onPlay}
+                    />
+                    {trackPlayer}
+                </RootPaper>
+            </PlayerSectionProvider>
         </PlayerTimeProvider>
     );
 };

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -1,7 +1,7 @@
 import UnstyledBackspaceIcon from "@mui/icons-material/Backspace";
 import BookmarkBorderOutlinedIcon from "@mui/icons-material/BookmarkBorderOutlined";
 import { Box, Slide, styled } from "@mui/material";
-import { grey, red } from "@mui/material/colors";
+import { red } from "@mui/material/colors";
 import { ChordBlock } from "common/ChordModel/ChordBlock";
 import { ChordLine } from "common/ChordModel/ChordLine";
 import { Collection, IDable } from "common/ChordModel/Collection";
@@ -9,9 +9,9 @@ import { Lyric } from "common/ChordModel/Lyric";
 import { DataTestID } from "common/DataTestID";
 import { PlainFn } from "common/PlainFn";
 import Block from "components/edit/Block";
-import WithHoverMenu, { MenuItem } from "components/edit/WithHoverMenu";
-import WithLyricInput from "components/edit/WithLyricInput";
-import WithSection from "components/edit/WithSection";
+import LineWithHoverMenu, { MenuItem } from "components/edit/LineWithHoverMenu";
+import LineWithLyricInput from "components/edit/LineWithLyricInput";
+import LineWithSection from "components/edit/LineWithSection";
 import { ChordSongAction } from "components/reducer/reducer";
 import { List } from "immutable";
 import React, { useMemo, useState } from "react";
@@ -26,7 +26,7 @@ const BackspaceIcon = styled(UnstyledBackspaceIcon)({
 
 const HighlightableBox = styled(Box)({
     "&:hover": {
-        backgroundColor: grey[100],
+        backgroundImage: "linear-gradient(rgba(0, 0, 0, 0.05) 0 0)",
     },
     whiteSpace: "nowrap",
     overflow: "hidden",
@@ -106,19 +106,19 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
     );
 
     const withHoverMenu = (startEdit: PlainFn, menuItems: MenuItem[]) => (
-        <WithHoverMenu menuItems={menuItems}>
+        <LineWithHoverMenu menuItems={menuItems}>
             {basicLine(startEdit)}
-        </WithHoverMenu>
+        </LineWithHoverMenu>
     );
 
     const withLyricInput = (menuItems: MenuItem[]) => (
-        <WithLyricInput chordLine={chordLine} songDispatch={songDispatch}>
+        <LineWithLyricInput chordLine={chordLine} songDispatch={songDispatch}>
             {(startEdit: PlainFn) => withHoverMenu(startEdit, menuItems)}
-        </WithLyricInput>
+        </LineWithLyricInput>
     );
 
     const withSection = (
-        <WithSection chordLine={chordLine} songDispatch={songDispatch}>
+        <LineWithSection chordLine={chordLine} songDispatch={songDispatch}>
             {(editLabel: PlainFn) => {
                 const menuItems: MenuItem[] = [
                     {
@@ -135,7 +135,7 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
 
                 return withLyricInput(menuItems);
             }}
-        </WithSection>
+        </LineWithSection>
     );
 
     const lineContent: React.ReactElement = withSection;
@@ -147,6 +147,7 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
             in={!removing}
             timeout={250}
             onExited={handlers.remove}
+            appear={false}
         >
             <AtomicSelectionBox>
                 <Box

--- a/src/components/edit/Line.tsx
+++ b/src/components/edit/Line.tsx
@@ -147,7 +147,6 @@ const Line: React.FC<LineProps> = (props: LineProps): JSX.Element => {
             in={!removing}
             timeout={250}
             onExited={handlers.remove}
-            appear={false}
         >
             <AtomicSelectionBox>
                 <Box

--- a/src/components/edit/LineWithHoverMenu.tsx
+++ b/src/components/edit/LineWithHoverMenu.tsx
@@ -25,13 +25,13 @@ export interface MenuItem extends DataTestID {
     onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
-export interface WithHoverMenuProps {
+export interface LineWithHoverMenuProps {
     children: React.ReactElement;
     menuItems: MenuItem[];
 }
 
-const WithHoverMenu: React.FC<WithHoverMenuProps> = (
-    props: WithHoverMenuProps
+const LineWithHoverMenu: React.FC<LineWithHoverMenuProps> = (
+    props: LineWithHoverMenuProps
 ): JSX.Element => {
     const buttons = props.menuItems.map((item: MenuItem, index: number) => (
         <HoverMenuButton
@@ -56,4 +56,4 @@ const WithHoverMenu: React.FC<WithHoverMenuProps> = (
     );
 };
 
-export default WithHoverMenu;
+export default LineWithHoverMenu;

--- a/src/components/edit/LineWithLyricInput.tsx
+++ b/src/components/edit/LineWithLyricInput.tsx
@@ -18,7 +18,7 @@ const LyricInput = styled(UnstyledLyricInput)<LyricInputProps>(({ theme }) => ({
     borderBottomWidth: "2px",
 }));
 
-interface WithLyricInputProps {
+interface LineWithLyricInputProps {
     children: (handleEdit: PlainFn) => React.ReactElement;
     chordLine: ChordLine;
     songDispatch: React.Dispatch<ChordSongAction>;
@@ -26,8 +26,8 @@ interface WithLyricInputProps {
 
 // this component is inherently quite coupled with Line & friends
 // however, this is a good opportunity to separate concerns and organize functionality
-const WithLyricInput: React.FC<WithLyricInputProps> = (
-    props: WithLyricInputProps
+const LineWithLyricInput: React.FC<LineWithLyricInputProps> = (
+    props: LineWithLyricInputProps
 ): JSX.Element => {
     const { editing, startEdit, finishEdit } = useEditingState();
     const { songDispatch, chordLine } = props;
@@ -111,7 +111,7 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
     return (
         <>
             {lineElement}
-            <Box position="absolute" left="0" bottom="2px" width="100%">
+            <Box position="absolute" left="0" bottom="0px" width="100%">
                 <LyricInput
                     variant={lyricTypographyVariant}
                     onFinish={handlers.lyricEdit}
@@ -127,4 +127,4 @@ const WithLyricInput: React.FC<WithLyricInputProps> = (
     );
 };
 
-export default WithLyricInput;
+export default LineWithLyricInput;

--- a/src/components/edit/LineWithSection.tsx
+++ b/src/components/edit/LineWithSection.tsx
@@ -29,14 +29,14 @@ export interface MenuItem extends DataTestID {
     onClick?: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
 }
 
-export interface WithSectionProps {
+export interface LineWithSectionProps {
     chordLine: ChordLine;
     songDispatch: React.Dispatch<ChordSongAction>;
     children: (editLabel: PlainFn) => React.ReactElement;
 }
 
-const WithSection: React.FC<WithSectionProps> = (
-    props: WithSectionProps
+const LineWithSection: React.FC<LineWithSectionProps> = (
+    props: LineWithSectionProps
 ): JSX.Element => {
     const { editing, startEdit, finishEdit } = useEditingState();
 
@@ -120,4 +120,4 @@ const WithSection: React.FC<WithSectionProps> = (
     );
 };
 
-export default WithSection;
+export default LineWithSection;

--- a/src/components/edit/LineWithSectionHighlight.tsx
+++ b/src/components/edit/LineWithSectionHighlight.tsx
@@ -1,0 +1,32 @@
+import { Box } from "@mui/material";
+import { alpha } from "@mui/system";
+import { PlayerSectionContext } from "components/PlayerSectionContext";
+import React, { useContext } from "react";
+
+export interface LineWithSectionHighlightProps {
+    children: React.ReactElement | React.ReactElement[];
+    sectionID: string | null;
+}
+
+const LineWithSectionHighlight: React.FC<LineWithSectionHighlightProps> = (
+    props: LineWithSectionHighlightProps
+): JSX.Element => {
+    const currentSectionID = useContext(PlayerSectionContext);
+
+    if (currentSectionID !== props.sectionID) {
+        return <Box>{props.children}</Box>;
+    }
+
+    return (
+        <Box
+            sx={(theme) => ({
+                backgroundColor: alpha(theme.palette.primary.dark, 0.1),
+            })}
+        >
+            {props.children}
+        </Box>
+    );
+};
+
+export default LineWithSectionHighlight;
+

--- a/src/components/edit/NewLine.tsx
+++ b/src/components/edit/NewLine.tsx
@@ -3,7 +3,7 @@ import { Divider as UnstyledDivider, Grid, styled } from "@mui/material";
 import { ChordLine } from "common/ChordModel/ChordLine";
 import { IDable } from "common/ChordModel/Collection";
 import { DataTestID } from "common/DataTestID";
-import WithHoverMenu, { MenuItem } from "components/edit/WithHoverMenu";
+import LineWithHoverMenu, { MenuItem } from "components/edit/LineWithHoverMenu";
 import { ChordSongAction } from "components/reducer/reducer";
 import React from "react";
 
@@ -45,7 +45,7 @@ const NewLine: React.FC<NewLineProps> = (props: NewLineProps): JSX.Element => {
     };
 
     return (
-        <WithHoverMenu menuItems={[menuItem]}>
+        <LineWithHoverMenu menuItems={[menuItem]}>
             <HighlightableGrid
                 container
                 direction="column"
@@ -55,7 +55,7 @@ const NewLine: React.FC<NewLineProps> = (props: NewLineProps): JSX.Element => {
             >
                 <Divider />
             </HighlightableGrid>
-        </WithHoverMenu>
+        </LineWithHoverMenu>
     );
 };
 

--- a/src/components/edit/menu/TransposeMenu.tsx
+++ b/src/components/edit/menu/TransposeMenu.tsx
@@ -5,12 +5,12 @@ import {
     DialogContent,
     DialogTitle,
     FormControl as UnstyledFormControl,
+    FormHelperText,
     Grid,
-    InputLabel,
     MenuItem,
     Select as UnstyledSelect,
     SelectChangeEvent,
-    styled
+    styled,
 } from "@mui/material";
 import { ChordSong } from "common/ChordModel/ChordSong";
 import { AllNotes, Note } from "common/music/foundation/Note";
@@ -69,7 +69,6 @@ const TransposeMenu: React.FC<TransposeMenuProps> = (
     };
 
     const createKeySelect = (
-        id: string,
         currentKey: Note,
         changeHandler: (event: SelectChangeEvent<unknown>) => void
     ) => {
@@ -80,7 +79,7 @@ const TransposeMenu: React.FC<TransposeMenuProps> = (
         }
 
         return (
-            <Select id={id} value={currentKey} onChange={changeHandler}>
+            <Select value={currentKey} onChange={changeHandler}>
                 {menuItems}
             </Select>
         );
@@ -93,26 +92,20 @@ const TransposeMenu: React.FC<TransposeMenuProps> = (
                 <Grid container direction="row">
                     <Grid item>
                         <FormControl>
-                            <InputLabel htmlFor="original-key">
-                                Original Key
-                            </InputLabel>
                             {createKeySelect(
-                                "original-key",
                                 keySelection.originalKey,
                                 keySelectChangeHandler("originalKey")
                             )}
+                            <FormHelperText>Original Key</FormHelperText>
                         </FormControl>
                     </Grid>
                     <Grid item>
                         <FormControl>
-                            <InputLabel htmlFor="transposed-key">
-                                Transposed Key
-                            </InputLabel>
                             {createKeySelect(
-                                "transposed-key",
                                 keySelection.transposedKey,
                                 keySelectChangeHandler("transposedKey")
                             )}
+                            <FormHelperText>Transposed Key</FormHelperText>
                         </FormControl>
                     </Grid>
                 </Grid>

--- a/src/components/play/Play.tsx
+++ b/src/components/play/Play.tsx
@@ -45,7 +45,7 @@ const PlayScreen: React.FC<PlayScreenProps> = (
                         collapsedButtonSx={{
                             backgroundColor: "transparent",
                         }}
-                        timeSections={props.song.timeSections}
+                        timestampedSections={props.song.timestampedSections}
                         tracklistLoad={tracklistLoad}
                         onTrackListChanged={onChange}
                         onRefresh={onRefresh}

--- a/src/components/track_player/JamStation.tsx
+++ b/src/components/track_player/JamStation.tsx
@@ -1,6 +1,6 @@
 import { Theme } from "@mui/material";
 import { SystemStyleObject } from "@mui/system";
-import { TimeSection } from "common/ChordModel/ChordLine";
+import { TimestampedSection } from "common/ChordModel/ChordLine";
 import { TrackList } from "common/ChordModel/tracks/TrackList";
 import { PlainFn } from "common/PlainFn";
 import TrackListEditDialog from "components/track_player/dialog/TrackListEditDialog";
@@ -16,7 +16,7 @@ type PlayerVisibilityState = "minimized" | "full";
 
 interface JamStationProps {
     tracklistLoad: TrackListLoad;
-    timeSections: List<TimeSection>;
+    timestampedSections: List<TimestampedSection>;
     onTrackListChanged: (trackList: TrackList) => void;
     onRefresh: PlainFn;
     collapsedButtonSx?: SystemStyleObject<Theme>;
@@ -42,7 +42,7 @@ const JamStation: React.FC<JamStationProps> = (
 
     const [currentTrackIndex, setCurrentTrackIndex] = useState(0);
 
-    const playerControls = usePlayerControls(props.timeSections);
+    const playerControls = usePlayerControls(props.timestampedSections);
 
     const trackListIsEmpty =
         props.tracklistLoad.state === "loaded" &&

--- a/src/components/track_player/internal_player/ControlPane.tsx
+++ b/src/components/track_player/internal_player/ControlPane.tsx
@@ -32,7 +32,6 @@ interface ControlPaneProps {
         level: number;
         onChange: (newLevel: number) => void;
     };
-    sectionLabel: string;
 }
 
 const RightJustifiedControlBox = styled(ControlGroupBox)({

--- a/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
@@ -41,7 +41,6 @@ const SingleTrackPlayer: React.FC<SingleTrackPlayerProps> = (
             <ControlPane
                 show={props.focused}
                 playing={props.playerControls.playing}
-                sectionLabel={props.playerControls.currentSectionLabel}
                 onTogglePlay={props.playerControls.togglePlay}
                 onJumpBack={props.playerControls.jumpBack}
                 onJumpForward={props.playerControls.jumpForward}

--- a/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
@@ -344,7 +344,6 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
             <ControlPane
                 show={props.focused}
                 playing={props.playerControls.playing}
-                sectionLabel={props.playerControls.currentSectionLabel}
                 onTogglePlay={props.playerControls.togglePlay}
                 onJumpBack={props.playerControls.jumpBack}
                 onJumpForward={props.playerControls.jumpForward}


### PR DESCRIPTION
Since pulling out the section label from the player, I've decided to add the indicator for which section is currently playing onto the chord paper itself.

This works by providing another context provider which states which section is currently at play, and all the lines will respond to it by adjusting its background color. Thankfully since the internal contents are memoized, the rerender of these colors is rather cheap.