### PR TITLE
Validate timestamped sections ordering

### DIFF
--- a/src/common/ChordModel/ChordLine.ts
+++ b/src/common/ChordModel/ChordLine.ts
@@ -60,21 +60,6 @@ export type TimestampedSection = iots.TypeOf<
 export type Section = iots.TypeOf<typeof SectionValidator>;
 export type ChordLineValidatedFields = iots.TypeOf<typeof ChordLineValidator>;
 
-export const timestampedSectionSortFn = (
-    a: TimestampedSection,
-    b: TimestampedSection
-): number => {
-    if (a.time < b.time) {
-        return -1;
-    }
-
-    if (a.time > b.time) {
-        return 1;
-    }
-
-    return 0;
-};
-
 type RecordType = {
     id: string;
     section?: Section;

--- a/src/common/ChordModel/ChordSong.ts
+++ b/src/common/ChordModel/ChordSong.ts
@@ -3,12 +3,12 @@ import {
     ChordLine,
     ChordLineValidatedFields,
     ChordLineValidator,
-    TimestampedSection
+    TimestampedSection,
 } from "common/ChordModel/ChordLine";
 import {
     Collection,
     CollectionMethods,
-    IDable
+    IDable,
 } from "common/ChordModel/Collection";
 import { Lyric } from "common/ChordModel/Lyric";
 import { Note } from "common/music/foundation/Note";
@@ -495,15 +495,17 @@ export class ChordSong
 
     validateTimestampedSections(): Error | null {
         const sections = this.timestampedSections;
+
+        let prevSectionName = "the beginning of the song";
         let prevTime = 0;
         for (const section of sections) {
-            console.log("prev time: ", prevTime);
             if (section.time < prevTime) {
                 return new Error(
-                    `Section ${section.name} has an earlier timestamp than the previous section`
+                    `Section ${section.name} has an earlier timestamp than ${prevSectionName}`
                 );
             }
 
+            prevSectionName = section.name;
             prevTime = section.time;
         }
 

--- a/src/common/ChordModel/ChordSong.ts
+++ b/src/common/ChordModel/ChordSong.ts
@@ -1,26 +1,25 @@
-import { Either, isLeft, left, right } from "fp-ts/lib/Either";
-import { Json, parse } from "fp-ts/Json";
-import * as iots from "io-ts";
-import { DateFromISOString } from "io-ts-types";
-import lodash from "lodash";
-import { User } from "components/user/userContext";
 import { ChordBlock } from "common/ChordModel/ChordBlock";
 import {
     ChordLine,
     ChordLineValidatedFields,
     ChordLineValidator,
-    TimestampedSection,
-    timestampedSectionSortFn,
+    TimestampedSection
 } from "common/ChordModel/ChordLine";
 import {
     Collection,
     CollectionMethods,
-    IDable,
+    IDable
 } from "common/ChordModel/Collection";
 import { Lyric } from "common/ChordModel/Lyric";
-import { List, Record } from "immutable";
 import { Note } from "common/music/foundation/Note";
 import { transposeSong } from "common/music/transpose/Transpose";
+import { User } from "components/user/userContext";
+import { Json, parse } from "fp-ts/Json";
+import { Either, isLeft, left, right } from "fp-ts/lib/Either";
+import { List, Record } from "immutable";
+import * as iots from "io-ts";
+import { DateFromISOString } from "io-ts-types";
+import lodash from "lodash";
 
 const MetadataValidator = iots.type({
     title: iots.string,
@@ -316,7 +315,6 @@ export class ChordSong
             }
         });
 
-        timestampedSections.sort(timestampedSectionSortFn);
         return List(timestampedSections);
     }
 
@@ -493,5 +491,22 @@ export class ChordSong
 
     transpose(fromKey: Note, toKey: Note): ChordSong {
         return transposeSong(this, fromKey, toKey);
+    }
+
+    validateTimestampedSections(): Error | null {
+        const sections = this.timestampedSections;
+        let prevTime = 0;
+        for (const section of sections) {
+            console.log("prev time: ", prevTime);
+            if (section.time < prevTime) {
+                return new Error(
+                    `Section ${section.name} has an earlier timestamp than the previous section`
+                );
+            }
+
+            prevTime = section.time;
+        }
+
+        return null;
     }
 }

--- a/src/components/display/SectionHighlight.tsx
+++ b/src/components/display/SectionHighlight.tsx
@@ -3,24 +3,20 @@ import LineWithSectionHighlight from "components/display/LineWithSectionHighligh
 import { List } from "immutable";
 import React from "react";
 
-export interface SectionHighlightProps {
-    sectionLines: List<ChordLine>;
+export const makeSection = (
+    sectionLines: List<ChordLine>,
     lineElementFn: (
         line: ChordLine
-    ) => React.ReactElement | React.ReactElement[];
-}
-
-const SectionHighlight: React.FC<SectionHighlightProps> = (
-    props: SectionHighlightProps
-): JSX.Element => {
-    const sectionID = props.sectionLines.get(0)?.id;
+    ) => React.ReactElement | React.ReactElement[]
+) => {
+    const sectionID = sectionLines.get(0)?.id;
     if (sectionID === undefined) {
         throw new Error("Sections are expected to have at least one line");
     }
 
     const makeLineElement = (line: ChordLine, index: number) => {
         const isTop = index === 0;
-        const isBottom = index === props.sectionLines.size - 1;
+        const isBottom = index === sectionLines.size - 1;
         return (
             <LineWithSectionHighlight
                 key={line.id}
@@ -28,15 +24,10 @@ const SectionHighlight: React.FC<SectionHighlightProps> = (
                 top={isTop}
                 bottom={isBottom}
             >
-                {props.lineElementFn(line)}
+                {lineElementFn(line)}
             </LineWithSectionHighlight>
         );
     };
 
-    const lines = props.sectionLines.map(makeLineElement);
-
-    return <>{lines}</>;
+    return sectionLines.map(makeLineElement);
 };
-
-export default SectionHighlight;
-

--- a/src/components/edit/ChordPaperBody.tsx
+++ b/src/components/edit/ChordPaperBody.tsx
@@ -2,12 +2,12 @@ import { Grid, Paper as UnstyledPaper, styled, Theme } from "@mui/material";
 import { SystemStyleObject } from "@mui/system";
 import { ChordLine } from "common/ChordModel/ChordLine";
 import { ChordSong } from "common/ChordModel/ChordSong";
-import SectionHighlight from "components/display/SectionHighlight";
+import { makeSection } from "components/display/SectionHighlight";
 import { handleBatchLineDelete } from "components/edit/BatchDelete";
 import { useLineCopyHandler } from "components/edit/CopyAndPaste";
 import {
     InteractionContext,
-    InteractionSetter,
+    InteractionSetter
 } from "components/edit/InteractionContext";
 import Line from "components/edit/Line";
 import NewLine from "components/edit/NewLine";
@@ -107,15 +107,8 @@ const ChordPaperBody: React.FC<ChordPaperBodyProps> = (
     };
 
     const lines: List<JSX.Element> = (() => {
-        let lines = props.song.timeSectionedChordLines.map(
-            (section: List<ChordLine>) => {
-                return (
-                    <SectionHighlight
-                        sectionLines={section}
-                        lineElementFn={makeLineElement}
-                    />
-                );
-            }
+        let lines = props.song.timeSectionedChordLines.flatMap(
+            (section: List<ChordLine>) => makeSection(section, makeLineElement)
         );
 
         const firstNewLine = (

--- a/src/components/play/scroll/ScrollPlayContent.tsx
+++ b/src/components/play/scroll/ScrollPlayContent.tsx
@@ -3,11 +3,11 @@ import { ChordLine } from "common/ChordModel/ChordLine";
 import { ChordSong } from "common/ChordModel/ChordSong";
 import { Collection } from "common/ChordModel/Collection";
 import { noopFn, PlainFn } from "common/PlainFn";
-import SectionHighlight from "components/display/SectionHighlight";
+import { makeSection } from "components/display/SectionHighlight";
 import { useNavigationKeys } from "components/play/common/useNavigateKeys";
 import {
     HighlightBorderContext,
-    HighlightBorderProvider
+    HighlightBorderProvider,
 } from "components/play/scroll/highlightBorderContext";
 import ScrollablePlayLine from "components/play/scroll/ScrollablePlayLine";
 import { List } from "immutable";
@@ -204,14 +204,8 @@ const ScrollPlayContent: React.FC<ScrollPlayContentProps> = (
     };
 
     const sections = props.song.timeSectionedChordLines.map(
-        (sectionLines: List<ChordLine>) => {
-            return (
-                <SectionHighlight
-                    sectionLines={sectionLines}
-                    lineElementFn={makePlayLine}
-                />
-            );
-        }
+        (sectionLines: List<ChordLine>) =>
+            makeSection(sectionLines, makePlayLine)
     );
 
     const scrollDown = (): boolean => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "noFallthroughCasesInSwitch": true,
-    "baseUrl": "src"
+    "baseUrl": "src",
+    "downlevelIteration": true
   },
   "include": [
     "src"


### PR DESCRIPTION
Adding a check to make sure that all the sections have monotonically increasing time in the order they appear.

In addition to the change itself, I also had to change the reducer to allow for bailing out of a state change if it fails validation. Turns out these cases already existed in the split/merge line functionality, but I hadn't handled it gracefully - it would add an additional entry in the undo stack of the same state.