### PR TITLE
Prevent setting section without song playing or at beginning of song

### DIFF
--- a/src/components/PlayerSectionContext.tsx
+++ b/src/components/PlayerSectionContext.tsx
@@ -19,11 +19,21 @@ const PlayerSectionProvider: React.FC<PlayerSectionProviderProps> = (
     useEffect(() => {
         const maybeSetNewSectionID = () => {
             const getPlayerTime = getPlayerTimeRef.current;
-            if (getPlayerTime === null) {
+
+            const currentTime = getPlayerTime();
+            const isBeginningOfSong = currentTime === 0;
+
+            // also avoiding setting an active section for the beginning of the song
+            // because it will cause sections to highlight or get labelled when in fact
+            // nothing started to play yet
+            if (currentTime === null || isBeginningOfSong) {
+                if (currentSectionID !== "") {
+                    setCurrentSectionID("");
+                }
+
                 return;
             }
 
-            const currentTime = getPlayerTime();
             const timestampedSections = props.song.timestampedSections;
 
             const nowTimestampedSection = findSectionAtTime(
@@ -42,7 +52,7 @@ const PlayerSectionProvider: React.FC<PlayerSectionProviderProps> = (
             setCurrentSectionID(nowSectionID);
         };
 
-        const intervalID = setInterval(maybeSetNewSectionID, 1000);
+        const intervalID = setInterval(maybeSetNewSectionID, 500);
 
         return () => clearInterval(intervalID);
     }, [props.song, currentSectionID, getPlayerTimeRef]);
@@ -55,4 +65,3 @@ const PlayerSectionProvider: React.FC<PlayerSectionProviderProps> = (
 };
 
 export default PlayerSectionProvider;
-

--- a/src/components/PlayerTimeContext.tsx
+++ b/src/components/PlayerTimeContext.tsx
@@ -1,11 +1,14 @@
-import React, { createRef, useRef } from "react";
+import React, { useRef } from "react";
 
-export type GetPlayerTimeFn = () => number;
-type GetPlayerTimeFnRef = React.MutableRefObject<GetPlayerTimeFn | null>;
+export type GetPlayerTimeFn = () => number | null;
+type GetPlayerTimeFnRef = React.MutableRefObject<GetPlayerTimeFn>;
 
-export const PlayerTimeContext = React.createContext<GetPlayerTimeFnRef>(
-    createRef()
-);
+const nullContextRef = {
+    current: () => null,
+};
+
+export const PlayerTimeContext =
+    React.createContext<GetPlayerTimeFnRef>(nullContextRef);
 
 interface PlayerTimeProviderProps {
     children: React.ReactNode;
@@ -14,8 +17,8 @@ interface PlayerTimeProviderProps {
 const PlayerTimeProvider: React.FC<PlayerTimeProviderProps> = (
     props: PlayerTimeProviderProps
 ) => {
-    const getPlayerTimeRef: GetPlayerTimeFnRef = useRef<GetPlayerTimeFn | null>(
-        null
+    const getPlayerTimeRef: GetPlayerTimeFnRef = useRef<GetPlayerTimeFn>(
+        () => null
     );
 
     return (

--- a/src/components/edit/TimeInput.tsx
+++ b/src/components/edit/TimeInput.tsx
@@ -108,11 +108,11 @@ const TimeInput: React.FC<TimeInputProps> = (
 
     const handleCurrentTimeButton = () => {
         const currentGetPlayerTime = getPlayerTimeRef.current;
-        if (currentGetPlayerTime === null) {
+        const playerTimeSeconds: number | null = currentGetPlayerTime();
+        if (playerTimeSeconds === null) {
             return;
         }
 
-        const playerTimeSeconds: number = currentGetPlayerTime();
         const newValue = secondsToString(playerTimeSeconds);
         setValue(newValue);
         finish(newValue);

--- a/src/components/track_player/internal_player/advanced_controls/ABLoopControl.tsx
+++ b/src/components/track_player/internal_player/advanced_controls/ABLoopControl.tsx
@@ -42,13 +42,7 @@ const ABLoopControl: React.FC<ABLoopControlProps> = (
     const showBButton = !isDefaultLoopSet;
 
     const getTime = (): number | null => {
-        const playerTimeFn = getPlayerTimeRef.current;
-
-        if (playerTimeFn === null) {
-            return null;
-        }
-
-        return playerTimeFn();
+        return getPlayerTimeRef.current();
     };
 
     const ensureMode = (abLoop: ABLoop): ABLoopMode => {


### PR DESCRIPTION
This change prevents section highlighting in 2 scenarios:
-a song isn't playing
-a song is at the beginning

Both of these may indicate that the user hasn't started playing the song yet and it may be a confusing UI to highlight something that the user hasn't interacted with.