### PR TITLE
Disable delete button for non-owners

### DIFF
--- a/src/components/edit/menu/ChordPaperMenu.tsx
+++ b/src/components/edit/menu/ChordPaperMenu.tsx
@@ -148,7 +148,7 @@ const ChordPaperMenu: React.FC<ChordPaperMenuProps> = (
                 />
             )}
 
-            {!props.song.isUnsaved() && props.song.isOwner(user) (
+            {!props.song.isUnsaved() && props.song.isOwner(user) && (
                 <SpeedDialAction
                     icon={<DeleteIcon />}
                     tooltipTitle="Delete Song"

--- a/src/components/edit/menu/ChordPaperMenu.tsx
+++ b/src/components/edit/menu/ChordPaperMenu.tsx
@@ -148,7 +148,7 @@ const ChordPaperMenu: React.FC<ChordPaperMenuProps> = (
                 />
             )}
 
-            {!props.song.isUnsaved() && user !== null && (
+            {!props.song.isUnsaved() && props.song.isOwner(user) (
                 <SpeedDialAction
                     icon={<DeleteIcon />}
                     tooltipTitle="Delete Song"


### PR DESCRIPTION
The delete button shows up in songs for people who aren't owners. The backend will still refuse the unauthorized request but it's a confusing UI to offer a button that never works, so this change disables that button for non-owners.