### PR TITLE
Improve track player performance

### DIFF
--- a/src/components/display/LineWithSectionHighlight.tsx
+++ b/src/components/display/LineWithSectionHighlight.tsx
@@ -33,9 +33,12 @@ const bottomLineStyle = (theme: Theme) => ({
 const LineWithSectionHighlight: React.FC<LineWithSectionHighlightProps> = (
     props: LineWithSectionHighlightProps
 ): JSX.Element => {
-    const currentSectionID = useContext(PlayerSectionContext);
+    const currentSectionItem = useContext(PlayerSectionContext);
 
-    if (currentSectionID !== props.sectionID) {
+    if (
+        currentSectionItem === null ||
+        currentSectionItem.timestampedSection.lineID !== props.sectionID
+    ) {
         return <SmoothTransitionBox>{props.children}</SmoothTransitionBox>;
     }
 

--- a/src/components/track_player/JamStation.tsx
+++ b/src/components/track_player/JamStation.tsx
@@ -57,7 +57,10 @@ const JamStation: React.FC<JamStationProps> = (
             sx={props.collapsedButtonSx}
             show={playerVisibilityState === "minimized"}
             playersLoaded={loadPlayers}
-            playerControls={playerControls}
+            playing={playerControls.playing}
+            togglePlay={playerControls.transport.togglePlay}
+            jumpBack={playerControls.transport.jumpBack}
+            jumpForward={playerControls.transport.jumpForward}
             tooltipMessage={tooltipMessage}
             disabled={disabled}
             onClick={expandFn}
@@ -69,9 +72,9 @@ const JamStation: React.FC<JamStationProps> = (
         props.onTrackListChanged?.(tracklist);
     };
 
-    const openTrackEditDialog = () => {
+    const openTrackEditDialog = useCallback(() => {
         setTrackEditDialogState({ open: true, randomID: shortid.generate() });
-    };
+    }, [setTrackEditDialogState]);
 
     const closeTrackEditDialog = () => {
         setTrackEditDialogState({ open: false, randomID: "" });

--- a/src/components/track_player/MicroPlayer.tsx
+++ b/src/components/track_player/MicroPlayer.tsx
@@ -5,10 +5,13 @@ import PlayIcon from "@mui/icons-material/PlayArrow";
 import RadioIcon from "@mui/icons-material/Radio";
 import { Button, Slide, Theme, Tooltip } from "@mui/material";
 import { SystemStyleObject } from "@mui/system";
+import { PlainFn } from "common/PlainFn";
 import { MUIStyledProps } from "common/styledProps";
 import { useRegisterTopKeyListener } from "components/GlobalKeyListener";
-import { roundedTopCornersStyle, withBottomRightBox } from "components/track_player/common";
-import { PlayerControls } from "components/track_player/internal_player/usePlayerControls";
+import {
+    roundedTopCornersStyle,
+    withBottomRightBox,
+} from "components/track_player/common";
 import React, { useEffect, useState } from "react";
 
 interface MicroPlayerProps extends MUIStyledProps {
@@ -16,7 +19,10 @@ interface MicroPlayerProps extends MUIStyledProps {
     playersLoaded: boolean;
     disabled?: boolean;
     tooltipMessage: string;
-    playerControls: PlayerControls;
+    playing: boolean;
+    togglePlay: PlainFn;
+    jumpBack: PlainFn;
+    jumpForward: PlainFn;
     onClick: () => void;
     sx?: SystemStyleObject<Theme>;
 }
@@ -30,11 +36,7 @@ const MicroPlayer: React.FC<MicroPlayerProps> = (
     );
 
     {
-        const togglePlay = props.playerControls.togglePlay;
-        const jumpBack = props.playerControls.jumpBack;
-        const jumpForward = props.playerControls.jumpForward;
-        const onClick = props.onClick;
-        const show = props.show;
+        const { show, onClick, togglePlay, jumpBack, jumpForward } = props;
 
         useEffect(() => {
             if (!show) {
@@ -114,7 +116,7 @@ const MicroPlayer: React.FC<MicroPlayerProps> = (
             return <JumpForwardIcon />;
         }
 
-        if (!props.playerControls.playing) {
+        if (!props.playing) {
             return <PauseIcon sx={{ color: "secondary.main" }} />;
         }
 
@@ -146,4 +148,4 @@ const MicroPlayer: React.FC<MicroPlayerProps> = (
     );
 };
 
-export default MicroPlayer;
+export default React.memo(MicroPlayer);

--- a/src/components/track_player/MultiTrackPlayer.tsx
+++ b/src/components/track_player/MultiTrackPlayer.tsx
@@ -216,4 +216,4 @@ const MultiTrackPlayer: React.FC<MultiTrackPlayerProps> = (
     );
 };
 
-export default MultiTrackPlayer;
+export default React.memo(MultiTrackPlayer);

--- a/src/components/track_player/TrackPlayer.tsx
+++ b/src/components/track_player/TrackPlayer.tsx
@@ -188,4 +188,4 @@ const LoadedTrackPlayer: React.FC<LoadedTrackPlayerProps> = (
     return <Collapse in={props.focused}>{innerPlayer}</Collapse>;
 };
 
-export default TrackPlayer;
+export default React.memo(TrackPlayer);

--- a/src/components/track_player/internal_player/ControlPane.tsx
+++ b/src/components/track_player/internal_player/ControlPane.tsx
@@ -1,33 +1,21 @@
 import { Box, styled } from "@mui/material";
-import { PlainFn } from "common/PlainFn";
-import { useRegisterTopKeyListener } from "components/GlobalKeyListener";
 import { controlPaneStyle } from "components/track_player/common";
-import { ABLoop } from "components/track_player/internal_player/ABLoop";
 import AdvancedControls from "components/track_player/internal_player/advanced_controls/AdvancedControls";
-import { ControlButton } from "components/track_player/internal_player/ControlButton";
-import ControlGroup, {
-    ControlGroupBox
-} from "components/track_player/internal_player/ControlGroup";
-import { ButtonActionAndState } from "components/track_player/internal_player/usePlayerControls";
-import React, { useEffect } from "react";
+import { ControlGroupBox } from "components/track_player/internal_player/ControlGroup";
+import TransportControl from "components/track_player/internal_player/TransportControl";
+import {
+    ABLoopControl,
+    TempoControl,
+    TransportActions,
+} from "components/track_player/internal_player/usePlayerControls";
+import React from "react";
 
 interface ControlPaneProps {
     show: boolean;
     playing: boolean;
-    onTogglePlay: PlainFn;
-    onJumpBack: PlainFn;
-    onJumpForward: PlainFn;
-    onGoToBeginning: PlainFn;
-    onSkipBack: ButtonActionAndState;
-    onSkipForward: ButtonActionAndState;
-    tempo: {
-        percentage: number;
-        onChange: (newPercentage: number) => void;
-    };
-    abLoop: {
-        abLoop: ABLoop;
-        onChange: (newABLoop: ABLoop) => void;
-    };
+    transport: TransportActions;
+    tempo: TempoControl;
+    abLoop: ABLoopControl;
     transpose?: {
         level: number;
         onChange: (newLevel: number) => void;
@@ -54,72 +42,13 @@ export const ControlPaneBox = styled(Box)(({ theme }) => {
 const ControlPane: React.FC<ControlPaneProps> = (
     props: ControlPaneProps
 ): JSX.Element => {
-    const [addTopKeyListener, removeKeyListener] = useRegisterTopKeyListener();
-
-    const playPauseButton = props.playing ? (
-        <ControlButton.Pause onClick={props.onTogglePlay} />
-    ) : (
-        <ControlButton.Play onClick={props.onTogglePlay} />
-    );
-
-    useEffect(() => {
-        if (!props.show) {
-            return;
-        }
-
-        const handleKey = (event: KeyboardEvent) => {
-            switch (event.code) {
-                case "Space": {
-                    props.onTogglePlay();
-                    event.preventDefault();
-
-                    break;
-                }
-                case "ArrowLeft": {
-                    if (event.ctrlKey || event.metaKey) {
-                        props.onSkipBack.action();
-                    } else {
-                        props.onJumpBack();
-                    }
-
-                    event.preventDefault();
-                    break;
-                }
-                case "ArrowRight": {
-                    if (event.ctrlKey || event.metaKey) {
-                        props.onSkipForward.action();
-                    } else {
-                        props.onJumpForward();
-                    }
-
-                    event.preventDefault();
-                    return;
-                }
-            }
-        };
-
-        addTopKeyListener(handleKey);
-        return () => {
-            removeKeyListener(handleKey);
-        };
-    }, [props, addTopKeyListener, removeKeyListener]);
-
     return (
         <ControlPaneBox>
-            <ControlGroup dividers="right">
-                <ControlButton.Beginning onClick={props.onGoToBeginning} />
-                <ControlButton.SkipBack
-                    disabled={!props.onSkipBack.enabled}
-                    onClick={props.onSkipBack.action}
-                />
-                <ControlButton.JumpBack onClick={props.onJumpBack} />
-                {playPauseButton}
-                <ControlButton.JumpForward onClick={props.onJumpForward} />
-                <ControlButton.SkipForward
-                    disabled={!props.onSkipForward.enabled}
-                    onClick={props.onSkipForward.action}
-                />
-            </ControlGroup>
+            <TransportControl
+                show={props.show}
+                playing={props.playing}
+                transport={props.transport}
+            />
             <RightJustifiedControlBox>
                 <AdvancedControls
                     tempo={props.tempo}

--- a/src/components/track_player/internal_player/TransportControl.tsx
+++ b/src/components/track_player/internal_player/TransportControl.tsx
@@ -1,0 +1,87 @@
+import { useRegisterTopKeyListener } from "components/GlobalKeyListener";
+import { ControlButton } from "components/track_player/internal_player/ControlButton";
+import ControlGroup from "components/track_player/internal_player/ControlGroup";
+import {
+    TransportActions
+} from "components/track_player/internal_player/usePlayerControls";
+import React, { useEffect } from "react";
+
+interface TransportControlProps {
+    show: boolean;
+    playing: boolean;
+    transport: TransportActions;
+}
+
+const TransportControl: React.FC<TransportControlProps> = (
+    props: TransportControlProps
+): JSX.Element => {
+    const [addTopKeyListener, removeKeyListener] = useRegisterTopKeyListener();
+
+    useEffect(() => {
+        if (!props.show) {
+            return;
+        }
+
+        const handleKey = (event: KeyboardEvent) => {
+            switch (event.code) {
+                case "Space": {
+                    props.transport.togglePlay();
+                    event.preventDefault();
+
+                    break;
+                }
+                case "ArrowLeft": {
+                    if (event.ctrlKey || event.metaKey) {
+                        props.transport.skipBack.action();
+                    } else {
+                        props.transport.jumpBack();
+                    }
+
+                    event.preventDefault();
+                    break;
+                }
+                case "ArrowRight": {
+                    if (event.ctrlKey || event.metaKey) {
+                        props.transport.skipForward.action();
+                    } else {
+                        props.transport.jumpForward();
+                    }
+
+                    event.preventDefault();
+                    return;
+                }
+            }
+        };
+
+        addTopKeyListener(handleKey);
+        return () => {
+            removeKeyListener(handleKey);
+        };
+    }, [props, addTopKeyListener, removeKeyListener]);
+
+    const playPauseButton = props.playing ? (
+        <ControlButton.Pause onClick={props.transport.togglePlay} />
+    ) : (
+        <ControlButton.Play onClick={props.transport.togglePlay} />
+    );
+
+    return (
+        <ControlGroup dividers="right">
+            <ControlButton.Beginning onClick={props.transport.goToBeginning} />
+            <ControlButton.SkipBack
+                disabled={!props.transport.skipBack.enabled}
+                onClick={props.transport.skipBack.action}
+            />
+            <ControlButton.JumpBack onClick={props.transport.jumpBack} />
+            {playPauseButton}
+            <ControlButton.JumpForward onClick={props.transport.jumpForward} />
+            <ControlButton.SkipForward
+                disabled={!props.transport.skipForward.enabled}
+                onClick={props.transport.skipForward.action}
+            />
+        </ControlGroup>
+    );
+};
+
+export default React.memo(TransportControl);
+

--- a/src/components/track_player/internal_player/advanced_controls/ABLoopControl.tsx
+++ b/src/components/track_player/internal_player/advanced_controls/ABLoopControl.tsx
@@ -3,20 +3,20 @@ import {
     Collapse,
     styled,
     ToggleButton as UnstyledToggleButton,
-    ToggleButtonGroup
+    ToggleButtonGroup,
 } from "@mui/material";
 import { PlayerTimeContext } from "components/PlayerTimeContext";
 import {
     ABLoop,
-    ABLoopMode
+    ABLoopMode,
 } from "components/track_player/internal_player/ABLoop";
 import { ControlButton } from "components/track_player/internal_player/ControlButton";
 import ControlGroup, {
-    ControlGroupBox
+    ControlGroupBox,
 } from "components/track_player/internal_player/ControlGroup";
 import { Either, isLeft } from "fp-ts/lib/Either";
 import { useSnackbar } from "notistack";
-import { useContext } from "react";
+import React, { useContext } from "react";
 
 const ToggleButton = styled(UnstyledToggleButton)(({ theme }) => ({
     border: "none",
@@ -156,4 +156,4 @@ const ABLoopControl: React.FC<ABLoopControlProps> = (
     );
 };
 
-export default ABLoopControl;
+export default React.memo(ABLoopControl);

--- a/src/components/track_player/internal_player/advanced_controls/AdvancedControls.tsx
+++ b/src/components/track_player/internal_player/advanced_controls/AdvancedControls.tsx
@@ -146,4 +146,4 @@ const AdvancedControls: React.FC<AdvancedControlsProps> = (
     return <>{menuElements}</>;
 };
 
-export default AdvancedControls;
+export default React.memo(AdvancedControls);

--- a/src/components/track_player/internal_player/advanced_controls/TempoControl.tsx
+++ b/src/components/track_player/internal_player/advanced_controls/TempoControl.tsx
@@ -54,4 +54,4 @@ const TempoControl: React.FC<TempoControlProps> = (
     );
 };
 
-export default TempoControl;
+export default React.memo(TempoControl);

--- a/src/components/track_player/internal_player/advanced_controls/TransposeControl.tsx
+++ b/src/components/track_player/internal_player/advanced_controls/TransposeControl.tsx
@@ -64,4 +64,4 @@ const TransposeControl: React.FC<TransposeControlProps> = (
     );
 };
 
-export default TransposeControl;
+export default React.memo(TransposeControl);

--- a/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/single/SingleTrackPlayer.tsx
@@ -41,12 +41,7 @@ const SingleTrackPlayer: React.FC<SingleTrackPlayerProps> = (
             <ControlPane
                 show={props.focused}
                 playing={props.playerControls.playing}
-                onTogglePlay={props.playerControls.togglePlay}
-                onJumpBack={props.playerControls.jumpBack}
-                onJumpForward={props.playerControls.jumpForward}
-                onSkipBack={props.playerControls.skipBack}
-                onSkipForward={props.playerControls.skipForward}
-                onGoToBeginning={props.playerControls.goToBeginning}
+                transport={props.playerControls.transport}
                 tempo={props.playerControls.tempo}
                 abLoop={props.playerControls.abLoop}
             />

--- a/src/components/track_player/internal_player/stem/StemTrackControlPane.tsx
+++ b/src/components/track_player/internal_player/stem/StemTrackControlPane.tsx
@@ -130,4 +130,4 @@ const StemTrackControlPane = <StemKey extends string>(
     return <Grid container>{buttons}</Grid>;
 };
 
-export default StemTrackControlPane;
+export default React.memo(StemTrackControlPane);

--- a/src/components/track_player/internal_player/usePlayerControls.ts
+++ b/src/components/track_player/internal_player/usePlayerControls.ts
@@ -1,13 +1,17 @@
 import { TimestampedSection } from "common/ChordModel/ChordLine";
-import {
-    findSectionAtTime
-} from "common/ChordModel/Section";
 import { noopFn, PlainFn } from "common/PlainFn";
+import { PlayerSectionContext } from "components/PlayerSectionContext";
 import { PlayerTimeContext } from "components/PlayerTimeContext";
 import { ABLoop } from "components/track_player/internal_player/ABLoop";
 import { List } from "immutable";
-import { Duration } from "luxon";
-import { useContext, useEffect, useRef, useState } from "react";
+import {
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+    useState
+} from "react";
 import ReactPlayer from "react-player";
 import FilePlayer from "react-player/file";
 import YouTubePlayer from "react-player/youtube";
@@ -17,17 +21,30 @@ export interface ButtonActionAndState {
     enabled: boolean;
 }
 
-export interface PlayerControls {
-    playerRef: React.MutableRefObject<ReactPlayer | FilePlayer | undefined>;
-    playing: boolean;
+export interface ABLoopControl {
+    abLoop: ABLoop;
+    onChange: (newABLoop: ABLoop) => void;
+}
+
+export interface TempoControl {
+    percentage: number;
+    onChange: (val: number) => void;
+}
+
+export interface TransportActions {
     togglePlay: PlainFn;
     jumpBack: PlainFn;
     jumpForward: PlainFn;
     goToBeginning: PlainFn;
     skipBack: ButtonActionAndState;
     skipForward: ButtonActionAndState;
-    currentTime: number;
-    currentTimeFormatted: string;
+}
+
+export interface PlayerControls {
+    playerRef: React.MutableRefObject<ReactPlayer | FilePlayer | undefined>;
+    playing: boolean;
+    transport: TransportActions;
+    getCurrentTime: () => number;
     onProgress: (state: {
         played: number;
         playedSeconds: number;
@@ -36,14 +53,8 @@ export interface PlayerControls {
     }) => void;
     onPlay: PlainFn;
     onPause: PlainFn;
-    tempo: {
-        percentage: number;
-        onChange: (val: number) => void;
-    };
-    abLoop: {
-        abLoop: ABLoop;
-        onChange: (newABLoop: ABLoop) => void;
-    };
+    tempo: TempoControl;
+    abLoop: ABLoopControl;
 }
 
 class NoopMutableRef {
@@ -63,20 +74,21 @@ class NoopMutableRef {
 export const unfocusedControls: PlayerControls = {
     playerRef: new NoopMutableRef(),
     playing: false,
-    togglePlay: noopFn,
-    jumpBack: noopFn,
-    jumpForward: noopFn,
-    goToBeginning: noopFn,
-    skipBack: {
-        action: noopFn,
-        enabled: false,
+    transport: {
+        togglePlay: noopFn,
+        jumpBack: noopFn,
+        jumpForward: noopFn,
+        goToBeginning: noopFn,
+        skipBack: {
+            action: noopFn,
+            enabled: false,
+        },
+        skipForward: {
+            action: noopFn,
+            enabled: false,
+        },
     },
-    skipForward: {
-        action: noopFn,
-        enabled: false,
-    },
-    currentTime: 0,
-    currentTimeFormatted: "0:00",
+    getCurrentTime: () => 0,
     onProgress: noopFn,
     onPlay: noopFn,
     onPause: noopFn,
@@ -106,15 +118,11 @@ export const usePlayerControls = (
     timestampedSections: List<TimestampedSection>
 ): PlayerControls => {
     const [playing, setPlaying] = useState(false);
-    const [currentTime, setCurrentTime] = useState(0);
+    const currentTimeRef = useRef<number>(0);
     const [abLoop, setABLoop] = useState<ABLoop>(ABLoop.empty());
     const playerRef = useRef<ReactPlayer | FilePlayer>();
     const [tempoPercentage, setTempoPercentage] = useState(100);
-
-    // a ref version so that a past render can access a future state
-    // see outOfSyncWorkaround for the reason
-    const currentTimeRef = useRef<number>(currentTime);
-    currentTimeRef.current = currentTime;
+    const currentSectionItem = useContext(PlayerSectionContext);
 
     const jumpInterval = 5; // seconds
 
@@ -124,124 +132,132 @@ export const usePlayerControls = (
     // the amount to skip to before the section - helps not drop the user right on the down beat
     const skipLeadIn = 1; // seconds;
 
+    const getCurrentTime = useCallback(() => currentTimeRef.current, []);
+
     {
         const getPlayerTimeRef = useContext(PlayerTimeContext);
-        const getCurrentTime = () => currentTimeRef.current;
 
         useEffect(() => {
             getPlayerTimeRef.current = getCurrentTime;
         }, [getPlayerTimeRef, getCurrentTime]);
     }
 
-    const seekTo = (time: number) => {
+    const seekTo = useCallback((time: number) => {
         if (time < 0) {
             time = 0;
         }
 
         playerRef.current?.seekTo(time, "seconds");
-    };
+    }, []);
 
-    const handlePlayState = () => {
+    const handlePlayState = useCallback(() => {
         setPlaying(true);
-    };
+    }, [setPlaying]);
 
-    const handlePauseState = () => {
+    const handlePauseState = useCallback(() => {
         setPlaying(false);
-    };
+    }, [setPlaying]);
 
-    const outOfSyncWorkaround = (nextSeekTime?: number) => {
-        const currentURL = playerRef.current?.props.url;
-        const applyWorkaround =
-            typeof currentURL === "string" && YouTubePlayer.canPlay(currentURL);
+    const outOfSyncWorkaround = useCallback(
+        (nextSeekTime?: number) => {
+            const currentURL = playerRef.current?.props.url;
+            const applyWorkaround =
+                typeof currentURL === "string" &&
+                YouTubePlayer.canPlay(currentURL);
 
-        if (applyWorkaround) {
-            // this is pretty unpleasant, but on certain videos, React Player can run into a race condition where
-            // it doesn't respond to playing=true/false, so the play and pause button doesn't actually affect the track
-            // this can be repro'd inconsistently by quickly toggling play/pause several times, or jump back, then pause in the compact player
-            //
-            // attempt at throttling didn't work, the wonkiness can occur even at 5 seconds of throttling depending on the course of events
-            // one observation is that this wonky state can be reset out of by performing a seek after it gets into this state
-            // however, it can't be too soon, hence the set timeout
-            // and also we would want to seek to the time of the most updated time, not the one during the current render, hence the use of ref
-            setTimeout(() => {
-                const seekTime = nextSeekTime ?? currentTimeRef.current;
-                seekTo(seekTime);
-            }, 200);
-        }
-    };
+            if (applyWorkaround) {
+                // this is pretty unpleasant, but on certain videos, React Player can run into a race condition where
+                // it doesn't respond to playing=true/false, so the play and pause button doesn't actually affect the track
+                // this can be repro'd inconsistently by quickly toggling play/pause several times, or jump back, then pause in the compact player
+                //
+                // attempt at throttling didn't work, the wonkiness can occur even at 5 seconds of throttling depending on the course of events
+                // one observation is that this wonky state can be reset out of by performing a seek after it gets into this state
+                // however, it can't be too soon, hence the set timeout
+                // and also we would want to seek to the time of the most updated time, not the one during the current render, hence the use of ref
+                setTimeout(() => {
+                    const seekTime = nextSeekTime ?? currentTimeRef.current;
+                    seekTo(seekTime);
+                }, 200);
+            }
+        },
+        [seekTo]
+    );
 
-    const pauseAction = (nextSeekTime?: number) => {
-        setPlaying(false);
-        outOfSyncWorkaround(nextSeekTime);
-    };
+    const pauseAction = useCallback(
+        (nextSeekTime?: number) => {
+            setPlaying(false);
+            outOfSyncWorkaround(nextSeekTime);
+        },
+        [setPlaying, outOfSyncWorkaround]
+    );
 
-    const playAction = () => {
+    const playAction = useCallback(() => {
         setPlaying(true);
-    };
+    }, [setPlaying]);
 
-    const togglePlayAction = () => {
+    const togglePlayAction = useCallback(() => {
         if (playing) {
             pauseAction();
         } else {
             playAction();
         }
-    };
+    }, [playAction, pauseAction, playing]);
 
-    const jumpBackAction = () => {
-        let newTime = currentTime - jumpInterval;
+    const jumpBackAction = useCallback(() => {
+        let newTime = currentTimeRef.current - jumpInterval;
         if (newTime < 0) {
             newTime = 0;
         }
 
         seekTo(newTime);
-    };
+    }, [seekTo]);
 
-    const jumpForwardAction = () => {
-        const newTime = currentTime + jumpInterval;
+    const jumpForwardAction = useCallback(() => {
+        const newTime = currentTimeRef.current + jumpInterval;
         seekTo(newTime);
-    };
+    }, [seekTo]);
 
-    const goToBeginningAction = () => {
+    const goToBeginningAction = useCallback(() => {
         seekTo(0);
-    };
+    }, [seekTo]);
 
-    const currentSection = findSectionAtTime(
-        timestampedSections,
-        currentTime
+    const skipBackButtonAction = useCallback(() => {
+        if (currentSectionItem === null) {
+            return;
+        }
+
+        const previousSection: TimestampedSection | null = (() => {
+            if (currentSectionItem === null || currentSectionItem.index === 0) {
+                return null;
+            }
+
+            return getSection(
+                timestampedSections,
+                currentSectionItem.index - 1
+            );
+        })();
+
+        if (
+            previousSection !== null &&
+            currentTimeRef.current <=
+                currentSectionItem.timestampedSection.time + skipBackBuffer
+        ) {
+            seekTo(previousSection.time - skipLeadIn);
+            return;
+        }
+
+        seekTo(currentSectionItem.timestampedSection.time - skipLeadIn);
+    }, [currentSectionItem, seekTo, timestampedSections]);
+
+    const skipBackButton: ButtonActionAndState = useMemo(
+        () => ({
+            action: skipBackButtonAction,
+            enabled: currentSectionItem !== null,
+        }),
+        [skipBackButtonAction, currentSectionItem]
     );
 
-    const skipBackButton: ButtonActionAndState = {
-        action: () => {
-            if (currentSection === null) {
-                return;
-            }
-
-            const previousSection: TimestampedSection | null = (() => {
-                if (currentSection === null || currentSection.index === 0) {
-                    return null;
-                }
-
-                return getSection(
-                    timestampedSections,
-                    currentSection.index - 1
-                );
-            })();
-
-            if (
-                previousSection !== null &&
-                currentTime <=
-                    currentSection.timestampedSection.time + skipBackBuffer
-            ) {
-                seekTo(previousSection.time - skipLeadIn);
-                return;
-            }
-
-            seekTo(currentSection.timestampedSection.time - skipLeadIn);
-        },
-        enabled: currentSection !== null,
-    };
-
-    const skipForwardButton: ButtonActionAndState = (() => {
+    const skipForwardButton: ButtonActionAndState = useMemo(() => {
         const findNextSectionIndex = (
             sectionIndex: number | null
         ): number | null => {
@@ -261,7 +277,7 @@ export const usePlayerControls = (
         };
 
         const currentSectionIndex =
-            currentSection !== null ? currentSection.index : null;
+            currentSectionItem !== null ? currentSectionItem.index : null;
         const nextSectionIndex = findNextSectionIndex(currentSectionIndex);
 
         // determine what the actual next section is - it could be the next one or next next one depending on the buffer
@@ -278,7 +294,7 @@ export const usePlayerControls = (
             // we could return section (n + 1) or section (n + 2)
             // the idea is that, e.g. the user is at 1:05 but the next section is at 1:06, and next next section is 1:30
             // then the user actually wants to go to 1:30 by skipping forward
-            if (currentTime < nextSection.time - skipForwardBuffer) {
+            if (currentTimeRef.current < nextSection.time - skipForwardBuffer) {
                 return nextSection;
             }
 
@@ -298,75 +314,113 @@ export const usePlayerControls = (
             },
             enabled: nextSectionToSkipTo !== null,
         };
-    })();
+    }, [currentSectionItem, seekTo, timestampedSections]);
 
-    const handleABLoop = (playedSeconds: number) => {
-        if (abLoop.mode === "disabled") {
-            return;
-        }
-
-        if (!abLoop.isSet()) {
-            return;
-        }
-
-        if (!abLoop.isPlayable()) {
-            return;
-        }
-
-        if (!abLoop.isOutsideLoop(playedSeconds)) {
-            return;
-        }
-
-        switch (abLoop.mode) {
-            case "loop": {
-                seekTo(abLoop.timeA);
+    const handleABLoop = useCallback(
+        (playedSeconds: number) => {
+            if (abLoop.mode === "disabled") {
                 return;
             }
 
-            case "rewind": {
-                seekTo(abLoop.timeA);
-                pauseAction(abLoop.timeA);
+            if (!abLoop.isSet()) {
                 return;
             }
-        }
-    };
 
-    const handleProgress = (state: {
-        played: number;
-        playedSeconds: number;
-        loaded: number;
-        loadedSeconds: number;
-    }) => {
-        setCurrentTime(state.playedSeconds);
-        handleABLoop(state.playedSeconds);
-    };
+            if (!abLoop.isPlayable()) {
+                return;
+            }
 
-    const currentTimeFormatted: string = (() => {
-        const duration: Duration = Duration.fromMillis(currentTime * 1000);
-        return duration.toFormat("m:ss");
-    })();
+            if (!abLoop.isOutsideLoop(playedSeconds)) {
+                return;
+            }
 
-    return {
-        playerRef: playerRef,
-        playing: playing,
-        togglePlay: togglePlayAction,
-        skipBack: skipBackButton,
-        skipForward: skipForwardButton,
-        jumpBack: jumpBackAction,
-        jumpForward: jumpForwardAction,
-        goToBeginning: goToBeginningAction,
-        currentTime: currentTime,
-        currentTimeFormatted: currentTimeFormatted,
-        onProgress: handleProgress,
-        onPlay: handlePlayState,
-        onPause: handlePauseState,
-        tempo: {
+            switch (abLoop.mode) {
+                case "loop": {
+                    seekTo(abLoop.timeA);
+                    return;
+                }
+
+                case "rewind": {
+                    seekTo(abLoop.timeA);
+                    pauseAction(abLoop.timeA);
+                    return;
+                }
+            }
+        },
+        [abLoop, pauseAction, seekTo]
+    );
+
+    const tempoControl = useMemo(
+        () => ({
             percentage: tempoPercentage,
             onChange: setTempoPercentage,
-        },
-        abLoop: {
+        }),
+        [tempoPercentage, setTempoPercentage]
+    );
+
+    const abLoopControl = useMemo(
+        () => ({
             abLoop: abLoop,
             onChange: setABLoop,
+        }),
+        [abLoop, setABLoop]
+    );
+
+    const handleProgress = useCallback(
+        (state: {
+            played: number;
+            playedSeconds: number;
+            loaded: number;
+            loadedSeconds: number;
+        }) => {
+            currentTimeRef.current = state.playedSeconds;
+            handleABLoop(state.playedSeconds);
         },
-    };
+        [handleABLoop]
+    );
+
+    const transportActions: TransportActions = useMemo(
+        () => ({
+            togglePlay: togglePlayAction,
+            skipBack: skipBackButton,
+            skipForward: skipForwardButton,
+            jumpBack: jumpBackAction,
+            jumpForward: jumpForwardAction,
+            goToBeginning: goToBeginningAction,
+        }),
+        [
+            togglePlayAction,
+            skipBackButton,
+            skipForwardButton,
+            jumpBackAction,
+            jumpForwardAction,
+            goToBeginningAction,
+        ]
+    );
+
+    const playerControls: PlayerControls = useMemo(
+        () => ({
+            playerRef: playerRef,
+            playing: playing,
+            getCurrentTime: getCurrentTime,
+            onProgress: handleProgress,
+            onPlay: handlePlayState,
+            onPause: handlePauseState,
+            transport: transportActions,
+            tempo: tempoControl,
+            abLoop: abLoopControl,
+        }),
+        [
+            playing,
+            getCurrentTime,
+            handleProgress,
+            handlePlayState,
+            handlePauseState,
+            transportActions,
+            tempoControl,
+            abLoopControl,
+        ]
+    );
+
+    return playerControls;
 };


### PR DESCRIPTION
A performance pass on the track player. Classic reduce the amount of renders performance pass. Issue was that a render on the track player was happening around every second, now it's been reduced to once per section and also lightening the render during those times.

Several things to make that happen:

-remove the currentTime state on usePlayerControls and use the ref exclusively instead as the source of truth. this way when an update happens, no rerender happens. this does force some of the consumers to set their own timers instead of waiting for a rerender, but the only place that needs it is the stem player for synchronization, and its reaction to the changing time is not a render anyway
-memoizing pretty much everything, including the props that come out of usePlayerControls and a lot of track player components
-pulling out the transport controls so that it can be independently memoized
-pulling the section detection out of usePlayerControls and switching over to the PlayerSectionContext instead
