### PR TITLE
Crash fix: update PlayerSectionContext when sections change

### DIFF
--- a/src/components/PlayerSectionContext.tsx
+++ b/src/components/PlayerSectionContext.tsx
@@ -1,10 +1,12 @@
+import { TimestampedSection } from "common/ChordModel/ChordLine";
 import { ChordSong } from "common/ChordModel/ChordSong";
 import {
     findSectionAtTime,
     TimestampedSectionItem,
 } from "common/ChordModel/Section";
 import { PlayerTimeContext } from "components/PlayerTimeContext";
-import React, { useContext, useEffect, useState } from "react";
+import { List } from "immutable";
+import React, { useCallback, useContext, useEffect, useRef, useState } from "react";
 
 const sectionCheckInterval = 250;
 
@@ -20,52 +22,59 @@ const PlayerSectionProvider: React.FC<PlayerSectionProviderProps> = (
     props: PlayerSectionProviderProps
 ) => {
     const getPlayerTimeRef = useContext(PlayerTimeContext);
+    const sectionsRef = useRef<List<TimestampedSection>>(props.song.timestampedSections);
     const [currentSection, setCurrentSection] =
         useState<TimestampedSectionItem | null>(null);
 
+    const maybeSetNewSection = useCallback(() => {
+        const getPlayerTime = getPlayerTimeRef.current;
+
+        const currentTime = getPlayerTime();
+        const isBeginningOfSong = currentTime === 0;
+
+        // also avoiding setting an active section for the beginning of the song
+        // because it will cause sections to highlight or get labelled when in fact
+        // nothing started to play yet
+        if (currentTime === null || isBeginningOfSong) {
+            if (currentSection !== null) {
+                setCurrentSection(null);
+            }
+
+            return;
+        }
+
+        const timestampedSections = sectionsRef.current;
+
+        const nowTimestampedSection = findSectionAtTime(
+            timestampedSections,
+            currentTime
+        );
+
+        const sectionChanged =
+            currentSection?.timestampedSection.lineID !==
+            nowTimestampedSection?.timestampedSection.lineID;
+
+        if (!sectionChanged) {
+            return;
+        }
+
+        setCurrentSection(nowTimestampedSection);
+    }, [currentSection, setCurrentSection, getPlayerTimeRef]);
+
+    const sectionsChanged = sectionsRef.current !== props.song.timestampedSections;
+    if (sectionsChanged) {
+        sectionsRef.current = props.song.timestampedSections;
+        maybeSetNewSection();
+    }
+
     useEffect(() => {
-        const maybeSetNewSection = () => {
-            const getPlayerTime = getPlayerTimeRef.current;
-
-            const currentTime = getPlayerTime();
-            const isBeginningOfSong = currentTime === 0;
-
-            // also avoiding setting an active section for the beginning of the song
-            // because it will cause sections to highlight or get labelled when in fact
-            // nothing started to play yet
-            if (currentTime === null || isBeginningOfSong) {
-                if (currentSection !== null) {
-                    setCurrentSection(null);
-                }
-
-                return;
-            }
-
-            const timestampedSections = props.song.timestampedSections;
-
-            const nowTimestampedSection = findSectionAtTime(
-                timestampedSections,
-                currentTime
-            );
-
-            const sectionChanged =
-                currentSection?.timestampedSection.lineID !==
-                nowTimestampedSection?.timestampedSection.lineID;
-
-            if (!sectionChanged) {
-                return;
-            }
-
-            setCurrentSection(nowTimestampedSection);
-        };
-
         const intervalID = setInterval(
             maybeSetNewSection,
             sectionCheckInterval
         );
 
         return () => clearInterval(intervalID);
-    }, [props.song, currentSection, getPlayerTimeRef]);
+    }, [maybeSetNewSection]);
 
     return (
         <PlayerSectionContext.Provider value={currentSection}>


### PR DESCRIPTION
Fixes https://github.com/veedubyou/chord-paper-fe/issues/367

The issue stems from the list and the current section provided by the PlayerSectionContext being out of sync. Example scenario:

time sections are size 3
current section is index 2 (i.e. the last one)

The user deletes the last section:
time sections are size 2
current section is index 2
therefore out of bounds

Ideally the context always provides a valid section - the fix is when the time sections change, reevaluate the current section. This is done outside of useEffect in the render to make sure there is no out of sync issues - that the current section is compatible with the list.