### PR TITLE
add default labels for split requests

### DIFF
--- a/src/common/ChordModel/tracks/SplitStemRequest.ts
+++ b/src/common/ChordModel/tracks/SplitStemRequest.ts
@@ -66,10 +66,21 @@ export class SplitStemTrack
         });
     }
 
+    static defaultLabel(splitType: SplitStemTypes): string {
+        switch (splitType) {
+            case "split_2stems":
+                return "2 stems";
+            case "split_4stems":
+                return "4 stems";
+            case "split_5stems":
+                return "5 stems";
+        }
+    }
+
     static newTrackRequest(splitType: SplitStemTypes): SplitStemTrack {
         return new SplitStemTrack(
             "",
-            "",
+            this.defaultLabel(splitType),
             splitType,
             "",
             "requested",


### PR DESCRIPTION
Small quality of life improvement - fill in a default label for split requests so that the user doesn't have to type in something inane all the time.