### PR TITLE
Try fixing time button race

### DIFF
--- a/src/components/edit/TimeInput.tsx
+++ b/src/components/edit/TimeInput.tsx
@@ -114,8 +114,6 @@ const TimeInput: React.FC<TimeInputProps> = (
         }
 
         const newValue = secondsToString(playerTimeSeconds);
-        setValue(newValue);
-        finish(newValue);
 
         // put the focus back into the input box
         if (
@@ -125,13 +123,16 @@ const TimeInput: React.FC<TimeInputProps> = (
         ) {
             inputBoxRef.current.focus();
         }
+
+        setValue(newValue);
+        finish(newValue);
     };
 
     const buttonAdornment = (
         <InputAdornment position="end">
             <IconButton
                 edge="end"
-                onClick={handleCurrentTimeButton}
+                onMouseDown={handleCurrentTimeButton}
                 size="large"
                 sx={{ padding: 0.5 }}
             >


### PR DESCRIPTION
The "set current time for section" button has a weird race where it would defocus the time input before the current time is set. Trying these changes to see if this fixes it.