### PR TITLE
Remove any empty lines on lyric paste

### DIFF
--- a/src/common/ChordModel/Lyric.ts
+++ b/src/common/ChordModel/Lyric.ts
@@ -57,11 +57,15 @@ export class Lyric {
         return this.serializedLyric === "";
     }
 
-    isEntirelySpace(): boolean {
+    isEntirelySpaceOrTab(): boolean {
         return (
-            isWhitespace(this.serializedLyric) ||
+            this.isEntirelySpace() ||
             isValidTabValue("serializedStr", this.serializedLyric)
         );
+    }
+
+    isEntirelySpace(): boolean {
+        return isWhitespace(this.serializedLyric);
     }
 
     isEqual(other: Lyric): boolean {

--- a/src/common/ChordModel/test/Lyric.test.ts
+++ b/src/common/ChordModel/test/Lyric.test.ts
@@ -56,34 +56,52 @@ describe("lyric tokenizer", () => {
             expect(new Lyric("  ").isEntirelySpace()).toEqual(true);
         });
 
+        test("tabs", () => {
+            expect(new Lyric("\ue100").isEntirelySpace()).toEqual(false);
+        }); 
+        
+        test("space mixed with letters", () => {
+            expect(new Lyric(" a").isEntirelySpace()).toEqual(false);
+        });
+    })
+
+    describe("isEntirelySpaceOrTab", () => {
+        test("single whitespace", () => {
+            expect(new Lyric(" ").isEntirelySpaceOrTab()).toEqual(true);
+        });
+
+        test("multiple whitespace", () => {
+            expect(new Lyric("  ").isEntirelySpaceOrTab()).toEqual(true);
+        });
+
         describe("serialized tab", () => {
             test("small size", () => {
-                expect(new Lyric("\ue100").isEntirelySpace()).toEqual(true);
+                expect(new Lyric("\ue100").isEntirelySpaceOrTab()).toEqual(true);
             });
 
             test("medium size", () => {
-                expect(new Lyric("\ue200").isEntirelySpace()).toEqual(true);
+                expect(new Lyric("\ue200").isEntirelySpaceOrTab()).toEqual(true);
             });
 
             test("large size", () => {
-                expect(new Lyric("\ue400").isEntirelySpace()).toEqual(true);
+                expect(new Lyric("\ue400").isEntirelySpaceOrTab()).toEqual(true);
             });
         });
 
         test("mixed space and serialized tab", () => {
-            expect(new Lyric(" \ue100").isEntirelySpace()).toEqual(false);
+            expect(new Lyric(" \ue100").isEntirelySpaceOrTab()).toEqual(false);
         });
 
         test("multiple serialized tab", () => {
-            expect(new Lyric("\ue200\ue200").isEntirelySpace()).toEqual(false);
+            expect(new Lyric("\ue200\ue200").isEntirelySpaceOrTab()).toEqual(false);
         });
 
         test("space mixed with letters", () => {
-            expect(new Lyric(" a").isEntirelySpace()).toEqual(false);
+            expect(new Lyric(" a").isEntirelySpaceOrTab()).toEqual(false);
         });
 
         test("serialized tab mixed with letters", () => {
-            expect(new Lyric("a\ue400").isEntirelySpace()).toEqual(false);
+            expect(new Lyric("a\ue400").isEntirelySpaceOrTab()).toEqual(false);
         });
     });
 

--- a/src/components/display/Lyric.tsx
+++ b/src/components/display/Lyric.tsx
@@ -35,8 +35,8 @@ const LyricDisplay: React.FC<LyricTypographyProps> = (
     const customClassName = props.className ?? "";
 
     const className = cx({
-        [spaceClassName]: props.children.isEntirelySpace(),
-        [wordClassName]: !props.children.isEntirelySpace(),
+        [spaceClassName]: props.children.isEntirelySpaceOrTab(),
+        [wordClassName]: !props.children.isEntirelySpaceOrTab(),
         [customClassName]: props.className !== undefined,
     });
 

--- a/src/components/reducer/reducer.ts
+++ b/src/components/reducer/reducer.ts
@@ -340,7 +340,11 @@ const chordSongReducerWithoutUndo = (
         }
 
         case "insert-overflow-lyrics": {
-            const newChordLines: ChordLine[] = action.overflowLyrics.map(
+            const newLyrics = action.overflowLyrics.filter(
+                (lyric: Lyric) => !lyric.isEntirelySpace() && !lyric.isEmpty()
+            );
+
+            const newChordLines: ChordLine[] = newLyrics.map(
                 (newLyricLine: Lyric) => ChordLine.fromLyrics(newLyricLine)
             );
             return song.addAfter(action.insertionLineID, ...newChordLines);


### PR DESCRIPTION
When copying and pasting lyrics, the copied lyrics may sometimes include empty lines of whitespaces from e.g. paragraph separation from the lyric source. This is rarely what the user would want as separation is provided by sections, and empty lines provide no material for annotating chords.

This change filters out these extraneous lines upon lyric pasting.