### PR TITLE
Auto scroll

### DIFF
--- a/src/common/ChordModel/ChordLine.ts
+++ b/src/common/ChordModel/ChordLine.ts
@@ -494,7 +494,7 @@ export class ChordLine
         return this.chordBlocks.getAtIndex(0).isEmpty();
     }
 
-    hasSection(): boolean {
+    isSectionHead(): boolean {
         return this.section !== undefined;
     }
 }

--- a/src/components/display/SectionHighlight.tsx
+++ b/src/components/display/SectionHighlight.tsx
@@ -3,12 +3,26 @@ import LineWithSectionHighlight from "components/display/LineWithSectionHighligh
 import { List } from "immutable";
 import React from "react";
 
+interface SectionProps {
+    sectionLines: List<ChordLine>;
+    lineElementFn: (
+        line: ChordLine
+    ) => React.ReactElement | React.ReactElement[];
+}
+
+const Section: React.FC<SectionProps> = (
+    props: SectionProps
+): React.ReactElement => {
+    const section = makeSection(props.sectionLines, props.lineElementFn);
+    return <>{section}</>;
+};
+
 export const makeSection = (
     sectionLines: List<ChordLine>,
     lineElementFn: (
         line: ChordLine
     ) => React.ReactElement | React.ReactElement[]
-) => {
+): List<React.ReactElement> => {
     const sectionID = sectionLines.get(0)?.id;
     if (sectionID === undefined) {
         throw new Error("Sections are expected to have at least one line");
@@ -31,3 +45,5 @@ export const makeSection = (
 
     return sectionLines.map(makeLineElement);
 };
+
+export default React.memo(Section);

--- a/src/components/play/scroll/ScrollablePlayLine.tsx
+++ b/src/components/play/scroll/ScrollablePlayLine.tsx
@@ -6,29 +6,54 @@ import { useInPageView } from "components/play/scroll/useInPageView";
 import { useScrollable } from "components/play/scroll/useScrollable";
 import React, { useCallback } from "react";
 
+interface ViewportMarginPercentage {
+    top: number;
+    bottom: number;
+}
+
 // these values determine the portion of the viewport that is used to consider
 // the next line that the user can scroll to
 // e.g. top: -25, bottom: -25 is equivalent to the area 25% vh to 75% vh from the top
 
-// the top margin prevents scrolls that end up only scrolling 1-2 lines because
+// the top area prevents scrolls that end up only scrolling 1-2 lines because
 // the upcoming section is very near the top
-const topCurrentViewportMarginPercent = -25;
-// the bottom margin prevents a super big jump, so the user has some lookahead
+const topPortionMargin: ViewportMarginPercentage = {
+    top: 0,
+    bottom: -70,
+};
+
+// the bottom area prevents a super big jump, so the user has some lookahead
 // and isn't scrolled to an entirely new section without continuity
-const bottomCurrentViewportMarginPercent = -25;
+const bottomPortionMargin: ViewportMarginPercentage = {
+    top: -70,
+    bottom: 0,
+};
+
+const currentViewportMargin: ViewportMarginPercentage = {
+    top: 0,
+    bottom: 0,
+};
 
 // these percentages project one viewport height above the current viewport,
 // that is, the area if the user scrolled up 100vh
 // this is used to scroll backwards and it can be 100% since the user
 // cannot lookahead backwards (nor is that a meaningful usecase)
-const topPreviousViewportMarginPercent = 100;
-const bottomPreviousViewportMarginPercent = -100;
+const previousViewportMargin: ViewportMarginPercentage = {
+    top: 100,
+    bottom: -100,
+};
+
+interface InViewCallbacks {
+    currentView: (isInView: () => boolean) => void;
+    previousView: (isInView: () => boolean) => void;
+    topPortion: (isInView: () => boolean) => void;
+    bottomPortion: (isInView: () => boolean) => void;
+}
 
 interface ScrollablePlayLineProps {
     chordLine: ChordLine;
     colourBorder: boolean;
-    isInCurrentViewFnCallback: (isInView: () => boolean) => void;
-    isInPreviousViewFnCallback: (isInView: () => boolean) => void;
+    inViewCallbacks: InViewCallbacks;
     scrollFnCallback: (scrollFn: PlainFn) => void;
     inViewChanged: PlainFn;
 }
@@ -36,16 +61,28 @@ interface ScrollablePlayLineProps {
 const ScrollablePlayLine = React.memo(
     (props: ScrollablePlayLineProps): JSX.Element => {
         const currentPageInViewRef = useInPageView({
-            topMarginPercentage: topCurrentViewportMarginPercent,
-            bottomMarginPercentage: bottomCurrentViewportMarginPercent,
-            isInViewFnCallback: props.isInCurrentViewFnCallback,
+            topMarginPercentage: currentViewportMargin.top,
+            bottomMarginPercentage: currentViewportMargin.bottom,
+            isInViewFnCallback: props.inViewCallbacks.currentView,
             inViewChanged: props.inViewChanged,
         });
 
         const previousPageInViewRef = useInPageView({
-            topMarginPercentage: topPreviousViewportMarginPercent,
-            bottomMarginPercentage: bottomPreviousViewportMarginPercent,
-            isInViewFnCallback: props.isInPreviousViewFnCallback,
+            topMarginPercentage: previousViewportMargin.top,
+            bottomMarginPercentage: previousViewportMargin.bottom,
+            isInViewFnCallback: props.inViewCallbacks.previousView,
+        });
+
+        const topPortionInViewRef = useInPageView({
+            topMarginPercentage: topPortionMargin.top,
+            bottomMarginPercentage: topPortionMargin.bottom,
+            isInViewFnCallback: props.inViewCallbacks.topPortion,
+        });
+
+        const bottomPortionInViewRef = useInPageView({
+            topMarginPercentage: bottomPortionMargin.top,
+            bottomMarginPercentage: bottomPortionMargin.bottom,
+            isInViewFnCallback: props.inViewCallbacks.bottomPortion,
         });
 
         const scrollRef = useScrollable(props.scrollFnCallback);
@@ -56,13 +93,23 @@ const ScrollablePlayLine = React.memo(
                     scrollRef.current = elem;
                     currentPageInViewRef(elem);
                     previousPageInViewRef(elem);
+                    topPortionInViewRef(elem);
+                    bottomPortionInViewRef(elem);
                 } else {
                     scrollRef.current = undefined;
                     currentPageInViewRef(null);
                     previousPageInViewRef(null);
+                    topPortionInViewRef(null);
+                    bottomPortionInViewRef(null);
                 }
             },
-            [currentPageInViewRef, previousPageInViewRef, scrollRef]
+            [
+                currentPageInViewRef,
+                previousPageInViewRef,
+                topPortionInViewRef,
+                bottomPortionInViewRef,
+                scrollRef,
+            ]
         );
 
         return (


### PR DESCRIPTION
Adding an auto scroll feature to the play scroll view. When playing the song, when the next section comes into play, it will automatically scroll to the head of that section.

This required that I split the viewport margins into current, current top (top 25/30% of the screen), and current bottom (bottom 25/30% of the screen) so that it can be composed more independently.