### PR TITLE
Add periodic logs to Tone js in prod

### DIFF
--- a/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
@@ -195,6 +195,15 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
         }
     }, [props.playerControls.playing]);
 
+    // TODO: remove completely after understanding player out of sync bug
+    useEffect(() => {
+        const intervalID = setInterval(() => {
+            console.log("Tone control current state", Tone.Transport.state);
+        }, 5000);
+
+        return () => clearInterval(intervalID);
+    }, [])
+
     const { tempo, getCurrentTime } = props.playerControls;
     // synchronize time
     useEffect(() => {

--- a/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
+++ b/src/components/track_player/internal_player/stem/LoadedStemTrackPlayer.tsx
@@ -199,6 +199,7 @@ const LoadedStemTrackPlayer = <StemKey extends string>(
     useEffect(() => {
         const intervalID = setInterval(() => {
             console.log("Tone control current state", Tone.Transport.state);
+            console.log("Tone control current time", Tone.Transport.seconds);
         }, 5000);
 
         return () => clearInterval(intervalID);


### PR DESCRIPTION
Fairly often enough, Tonejs and the player gets out of sync in terms of player state - the player UI keeps going but nothing is playing. Suspicion is that some handling is causing a missing state. Adding periodic logging every 5 seconds to see what's going on. The reason this is done is because it's hard to reproduce this locally, but it happens easily in prod.